### PR TITLE
testcase: Watch Skylight window create/destroy events

### DIFF
--- a/examples/slwin.rs
+++ b/examples/slwin.rs
@@ -1,0 +1,131 @@
+use std::{
+    cell::RefCell,
+    ffi::c_void,
+    future::pending,
+    ptr::null_mut,
+    rc::{Rc, Weak},
+};
+
+use core_foundation::runloop::kCFRunLoopAllActivities;
+use core_graphics::base::CGError;
+use glide_wm::sys::{
+    app::ProcessInfo,
+    executor::Executor,
+    window_server::{self, SkylightNotifier, WindowServerId, kCGSWindowIsTerminated},
+};
+use objc2::MainThreadMarker;
+use objc2_core_foundation::{
+    CFRunLoop, CFRunLoopActivity, CFRunLoopObserver, kCFRunLoopCommonModes,
+};
+use objc2_core_graphics::CGSetLocalEventsSuppressionInterval;
+use tracing::{debug, info, trace, warn};
+
+struct Watcher {
+    #[expect(dead_code)]
+    create_notifier: SkylightNotifier,
+    destroy_notifier: SkylightNotifier,
+}
+
+#[expect(non_upper_case_globals)]
+const kCGSWindowDidCreate: u32 = 811;
+
+impl Watcher {
+    fn new() -> Rc<RefCell<Self>> {
+        Rc::new_cyclic(|state: &Weak<RefCell<Self>>| {
+            let create_notifier =
+                SkylightNotifier::new_for_event(kCGSWindowDidCreate, Self::make_handler(state))
+                    .expect("Initializing SkylightNotifier 1");
+            let mut destroy_notifier =
+                SkylightNotifier::new_for_event(kCGSWindowIsTerminated, Self::make_handler(state))
+                    .expect("Initializing SkylightNotifier 2");
+            for win in window_server::get_visible_windows_with_layer(Some(0)) {
+                if let Err(e) = destroy_notifier.add_window(win.id) {
+                    warn!("failed to add window: {e:?}");
+                }
+            }
+            RefCell::new(Watcher {
+                create_notifier,
+                destroy_notifier,
+            })
+        })
+    }
+
+    fn make_handler(state: &Weak<RefCell<Self>>) -> impl Fn(u32, &[u8]) + 'static {
+        let state = state.clone();
+        move |event, data| {
+            #[expect(non_upper_case_globals)]
+            match event {
+                kCGSWindowIsTerminated | kCGSWindowDidCreate => (),
+                _ => {
+                    println!("Got unexpected event {event}");
+                    return;
+                }
+            }
+            assert_eq!(data.len(), size_of::<WindowServerId>());
+            // SAFETY: We just asserted the correct size.
+            let wsid: WindowServerId = unsafe { *data.as_ptr().cast() };
+            let Some(state) = state.upgrade() else {
+                println!("could not upgrade state in callback");
+                return;
+            };
+            state.borrow_mut().on_event(event, wsid);
+        }
+    }
+
+    fn on_event(&mut self, event: u32, wsid: WindowServerId) {
+        #[expect(non_upper_case_globals)]
+        match event {
+            kCGSWindowDidCreate => {
+                let Some(info) = window_server::get_window(wsid) else {
+                    warn!("saw new window {wsid:?} but couldn't get info for it");
+                    return;
+                };
+                if let Ok(proc_info) = ProcessInfo::for_pid(info.pid)
+                    && proc_info.is_xpc
+                {
+                    trace!("filtering out window {wsid:?} for xpc service {}", info.pid);
+                    return;
+                }
+                println!("window created: {wsid:?}");
+                println!("=> {info:?}");
+                if let Err(e) = self.destroy_notifier.add_window(wsid) {
+                    warn!("failed to add window: {e:?}");
+                }
+            }
+            kCGSWindowIsTerminated => {
+                info!("window destroyed: {wsid:?}");
+                self.destroy_notifier.on_window_destroyed(wsid);
+            }
+            _ => unreachable!(),
+        }
+    }
+}
+
+async fn timer_task() {
+    let mut timer = glide_wm::sys::timer::Timer::new(0.0, 4.0);
+    while let Some(()) = timer.next().await {
+        tracing::info!("timer fired");
+    }
+}
+
+unsafe extern "C" {
+    safe fn CGEnableEventStateCombining(combineState: bool) -> CGError;
+}
+
+fn main() {
+    glide_wm::log::init_logging();
+    dbg!(CGSetLocalEventsSuppressionInterval(0.0));
+    dbg!(CGEnableEventStateCombining(false));
+    let _watcher = Watcher::new();
+    let observer = unsafe {
+        CFRunLoopObserver::new(None, kCFRunLoopAllActivities, true, 0, Some(obs), null_mut())
+    };
+    CFRunLoop::current()
+        .unwrap()
+        .add_observer(observer.as_deref(), unsafe { kCFRunLoopCommonModes });
+    Executor::run_main(MainThreadMarker::new().unwrap(), pending());
+}
+
+unsafe extern "C-unwind" fn obs(_: *mut CFRunLoopObserver, act: CFRunLoopActivity, _: *mut c_void) {
+    debug!("runloop: {act:?}");
+}


### PR DESCRIPTION
- **fix(#10): Use skylight APIs for backup window destroy events**
- **slwin: Watch Skylight window create/destroy events**

    Testcase for investigating behavior I saw in #21. On 26.1 Beta
    (25B5062e) it seems to delay getting destroy events until the next user
    input (keyboard or mouse), regardless of what app is focused when the
    event happens.

Note that this reproduces with an app like TextEdit;
    don't use iTerm2. Make sure there are at least two windows in the app and close one.

Other things I learned:

When the window closes the run loop wakes up, but does not see/fire the SLS event.

Then when there is an input event (even while the other app is focused), the run loop wakes up again and fires the event.

Input events do _not_ normally cause the run loop to wake up.

The events only fire when using `[NSApp run]`; regular run loop does not fire these. (This seems related to https://github.com/glide-wm/glide/commit/8de45f12f7bd25ceb7ab456dd5cc2c7cd5aaee97.)

It also does not work with a new SLS connection; has to be the main one or at least default one for the thread.

The SLS connection is not added as a source to the main thread run loop. Instead, AppKit spawns a separate event thread and handles messages there, then runs an SLS-specific handler as a block on the main run loop.

So we're definitely leaning on AppKit to do some setup for us to get the private APIs working, and then they aren't working the way we'd like. Maybe it's just holding it wrong. I haven't found any reports like this though and looking through code of other projects like yabai and rift did not surface anything promising.