### PR TITLE
improve(config): Change preferred config path to ~/.config/glide/glide.toml

### DIFF
--- a/src/bin/glide.rs
+++ b/src/bin/glide.rs
@@ -7,7 +7,7 @@ use anyhow::{Context, bail};
 use clap::{Parser, Subcommand};
 use glide_wm::{
     actor::server::{self, AsciiEscaped, Request, Response, ServiceRequest},
-    config::{Config, config_path_default},
+    config::{Config, config_path},
     sys::{
         bundle::{self, BundleError},
         message_port::{RemoteMessagePort, RemotePortCreateError, SendError},
@@ -127,7 +127,7 @@ fn main() -> Result<(), anyhow::Error> {
         }) => {
             let mut client = make_client()?;
             let mut update_config = || {
-                if !config.as_deref().unwrap_or(&config_path_default()).exists() {
+                if !config.as_deref().unwrap_or(&config_path()).exists() {
                     eprintln!("Warning: Config file missing; will load defaults");
                 }
                 let config = match Config::load(config.as_deref()) {
@@ -155,7 +155,7 @@ fn main() -> Result<(), anyhow::Error> {
             if watch {
                 let (tx, rx) = mpsc::channel();
                 let mut debouncer = new_debouncer(Duration::from_millis(50), tx)?;
-                debouncer.watcher().watch(&config_path_default(), RecursiveMode::NonRecursive)?;
+                debouncer.watcher().watch(&config_path(), RecursiveMode::NonRecursive)?;
                 update_config();
                 for event in rx {
                     event?;
@@ -169,7 +169,7 @@ fn main() -> Result<(), anyhow::Error> {
             config,
             action: ConfigSubcommand::Verify,
         }) => {
-            if !config.as_deref().unwrap_or(&config_path_default()).exists() {
+            if !config.as_deref().unwrap_or(&config_path()).exists() {
                 bail!("Config file missing");
             }
             if let Err(e) = Config::load(config.as_deref()) {

--- a/src/config.rs
+++ b/src/config.rs
@@ -26,7 +26,7 @@ pub fn restore_file() -> PathBuf {
     data_dir().join("layout.ron")
 }
 
-pub fn config_path_default() -> PathBuf {
+pub fn config_path() -> PathBuf {
     let default_path = dirs::config_local_dir().unwrap().join("glide/glide.toml");
     let try_paths = [
         default_path.clone(),
@@ -156,7 +156,7 @@ impl ConfigPartial {
 impl Config {
     pub fn load(custom_path: Option<&Path>) -> anyhow::Result<Config> {
         let mut buf = String::new();
-        let default = config_path_default();
+        let default = config_path();
         let (mut file, path) = match custom_path {
             Some(path) => (File::open(path)?, path),
             None => match File::open(&default) {


### PR DESCRIPTION
ok so basically you were right; dirs::config_home() goes to some stupid dumb idiotic place that i have never heard of. good portion of power users go to .config since it's easy to go across both linux and macos using this standard. 

dirs::config_local_home() takes you to .config or XDG_CONFIG_HOME, which is nicer. 

i'd say that it's better to keep the configs of applications like this in XDG_CONFIG_HOME so as to avoid cluttering home, but also keep in line with what other people do (which is have their config in XDG_CONFIG_HOME).