### PR TITLE
Enable status icon by default

### DIFF
--- a/glide.default.toml
+++ b/glide.default.toml
@@ -32,6 +32,9 @@ group_bars.thickness = 6
 group_bars.horizontal_placement = "top"
 group_bars.vertical_placement = "right"
 
+# Enables the status icon.
+status_icon.enable = true
+
 [keys]
 # Note: Modifier and key names must be capitalized.
 
@@ -118,11 +121,11 @@ group_bars.vertical_placement = "right"
 # the future. Use at your own risk!
 [settings.experimental]
 
-# Enables the experimental status icon.
-status_icon.enable = false
-
 # Show the current space index on the status icon.
 status_icon.space_index = false
 
 # Use color in the icon.
 status_icon.color = false
+
+# Ignored; kept for compatibility.
+status_icon.enable = true

--- a/src/actor/status.rs
+++ b/src/actor/status.rs
@@ -61,7 +61,7 @@ impl Status {
 
     fn apply_config(&mut self) {
         let icon = self.icon.take();
-        if self.config.settings.experimental.status_icon.enable {
+        if self.config.settings.status_icon.enable {
             self.icon = icon.or_else(|| {
                 Some(StatusIcon::new(
                     &self.config.settings.experimental.status_icon,

--- a/src/config.rs
+++ b/src/config.rs
@@ -58,6 +58,8 @@ pub struct Settings {
     pub inner_gap: f64,
     #[derive_args(GroupBarsPartial)]
     pub group_bars: GroupBars,
+    #[derive_args(StatusIconPartial)]
+    pub status_icon: StatusIcon,
     #[derive_args(ExperimentalPartial)]
     pub experimental: Experimental,
 }
@@ -67,8 +69,8 @@ pub struct Settings {
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct Experimental {
-    #[derive_args(StatusIconPartial)]
-    pub status_icon: StatusIcon,
+    #[derive_args(StatusIconExperimentalPartial)]
+    pub status_icon: StatusIconExperimental,
 }
 
 #[derive(PartialConfig!)]
@@ -77,8 +79,18 @@ pub struct Experimental {
 #[serde(deny_unknown_fields)]
 pub struct StatusIcon {
     pub enable: bool,
+}
+
+#[derive(PartialConfig!)]
+#[derive_args(StatusIconExperimentalPartial)]
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct StatusIconExperimental {
     pub space_index: bool,
     pub color: bool,
+
+    #[deprecated = "Ignored; kept for compatibility."]
+    pub enable: bool,
 }
 
 #[derive(PartialConfig!)]

--- a/src/config/partial.rs
+++ b/src/config/partial.rs
@@ -168,15 +168,17 @@ macro_rules! PartialConfig {
                 [
                     $($fields)*
 
-                    $(#[$field_meta])*
+                    $(#[$($field_meta)*])*
                     $field_name: Option<$field_ty>,
                 ];
                 [
                     $($merge)*
+                    #[allow(deprecated)]
                     $field_name: $high.$field_name.or($low.$field_name),
                 ];
                 [
                     $($check)*
+                    #[allow(deprecated)]
                     if $self.$field_name.is_none() {
                         $err.fields.push(stringify!($field_name));
                     }
@@ -185,6 +187,7 @@ macro_rules! PartialConfig {
                     $($validate)*
                     // We can unwrap because we will have returned if any fields
                     // were None already.
+                    #[allow(deprecated)]
                     $field_name: $self.$field_name.unwrap(),
                 ]
             ]

--- a/src/ui/status_bar.rs
+++ b/src/ui/status_bar.rs
@@ -41,7 +41,7 @@ pub struct StatusIcon {
 impl StatusIcon {
     /// Creates a new menu bar manager.
     pub fn new(
-        config: &config::StatusIcon,
+        config: &config::StatusIconExperimental,
         mtm: MainThreadMarker,
         reactor_tx: ReactorSender,
         wm_tx: wm_controller::Sender,
@@ -238,7 +238,7 @@ impl MenuHandler {
     }
 }
 
-fn create_parachute_icon(config: &config::StatusIcon) -> Option<Retained<NSImage>> {
+fn create_parachute_icon(config: &config::StatusIconExperimental) -> Option<Retained<NSImage>> {
     // Load the SVG file
     let svg_data = if config.color {
         include_str!("../../site/src/assets/parachute-small.svg")


### PR DESCRIPTION
@y3owk1n I tweaked the menu labels a bit to help distinguish the space and global disable options. Please take a look.

<img width="180" height="177" alt="Screenshot 2026-01-24 at 11 07 35 AM" src="https://github.com/user-attachments/assets/8a5b1543-4634-4e28-94fe-a3b76cb02258" />
