### PR TITLE
fix(config): path resolution

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -402,16 +402,4 @@ mod tests {
         assert!(config.keys.iter().any(|(hk, _)| hk.to_string() == "Alt + ArrowUp"));
         assert!(config.keys.iter().any(|(hk, _)| hk.to_string() == "Alt + ArrowRight"));
     }
-
-    #[test]
-    #[ignore = "only for debug purposes"]
-    fn print_config_search_paths() {
-        let candidates = default_config_paths();
-
-        eprintln!("Config candidates (in search order):");
-        for (index, path) in candidates.iter().enumerate() {
-            eprintln!("  {}. {}", index + 1, path.display());
-        }
-        eprintln!("Resolved config_path(): {}", config_path().display());
-    }
 }


### PR DESCRIPTION
closes https://github.com/glide-wm/glide/issues/146

`config_local_dir` results in `~/Library/Application Support`

For macos we should use https://docs.rs/dirs/latest/dirs/fn.home_dir.html