### PR TITLE
feat(nix): add flake.nix for macOS builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@
 
 # macOS
 .DS_Store/
+
+# Nix
+result

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1772479524,
+        "narHash": "sha256-u7nCaNiMjqvKpE+uZz9hE7pgXXTmm5yvdtFaqzSzUQI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "4215e62dc2cd3bc705b0a423b9719ff6be378a43",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,131 @@
+{
+  description = "Glide is a tiling window manager for macOS.";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+  };
+
+  outputs = { self, nixpkgs }:
+    let
+      lib = nixpkgs.lib;
+      cargoToml = builtins.fromTOML (builtins.readFile ./Cargo.toml);
+      packagerMeta = cargoToml.package.metadata.packager;
+      productName = packagerMeta.productName;
+      bundleName = "${productName}.app";
+      bundleIdentifier = packagerMeta.identifier;
+      version = cargoToml.package.version;
+      supportedSystems = [
+        "aarch64-darwin"
+        "x86_64-darwin"
+      ];
+      forAllSystems = f:
+        lib.genAttrs supportedSystems (
+          system: f (import nixpkgs { inherit system; })
+        );
+      mkGlide = pkgs:
+        pkgs.rustPlatform.buildRustPackage {
+          pname = cargoToml.package.name;
+          inherit version;
+
+          src = pkgs.lib.cleanSource ./.;
+
+          cargoLock = {
+            lockFile = ./Cargo.lock;
+            allowBuiltinFetchGit = true;
+          };
+
+          doCheck = false;
+
+          meta = with pkgs.lib; {
+            description = cargoToml.package.description;
+            homepage = cargoToml.package.homepage;
+            license = [
+              licenses.asl20
+              licenses.mit
+            ];
+            mainProgram = "glide";
+            platforms = platforms.darwin;
+          };
+        };
+      mkGlideBundle = pkgs: unbundled:
+        pkgs.runCommand "${cargoToml.package.name}-app-${version}" {
+          meta = with pkgs.lib; {
+            description = "${cargoToml.package.description} (${bundleName})";
+            homepage = cargoToml.package.homepage;
+            license = [
+              licenses.asl20
+              licenses.mit
+            ];
+            mainProgram = "glide";
+            platforms = platforms.darwin;
+          };
+        } ''
+          bundle="$out/Applications/${bundleName}"
+
+          mkdir -p "$bundle/Contents/MacOS" "$out/bin"
+
+          install -m755 ${unbundled}/bin/glide "$bundle/Contents/MacOS/glide"
+          install -m755 ${unbundled}/bin/glide_server "$bundle/Contents/MacOS/glide_server"
+
+          printf '%s\n' \
+            '<?xml version="1.0" encoding="UTF-8"?>' \
+            '<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">' \
+            '<plist version="1.0">' \
+            '  <dict>' \
+            '    <key>CFBundleDevelopmentRegion</key>' \
+            '    <string>en</string>' \
+            '    <key>CFBundleExecutable</key>' \
+            '    <string>glide_server</string>' \
+            '    <key>CFBundleIdentifier</key>' \
+            '    <string>${bundleIdentifier}</string>' \
+            '    <key>CFBundleInfoDictionaryVersion</key>' \
+            '    <string>6.0</string>' \
+            '    <key>CFBundleName</key>' \
+            '    <string>${productName}</string>' \
+            '    <key>CFBundlePackageType</key>' \
+            '    <string>APPL</string>' \
+            '    <key>CFBundleShortVersionString</key>' \
+            '    <string>${version}</string>' \
+            '    <key>CFBundleVersion</key>' \
+            '    <string>${version}</string>' \
+            '    <key>NSPrincipalClass</key>' \
+            '    <string>NSApplication</string>' \
+            '  </dict>' \
+            '</plist>' \
+            > "$bundle/Contents/Info.plist"
+
+          printf 'APPL????' > "$bundle/Contents/PkgInfo"
+
+          ln -s "../Applications/${bundleName}/Contents/MacOS/glide" "$out/bin/glide"
+          ln -s "../Applications/${bundleName}/Contents/MacOS/glide_server" "$out/bin/glide_server"
+
+          printf '%s\n' \
+            '#!/bin/sh' \
+            "exec \"$out/bin/glide\" launch \"\$@\"" \
+            > "$out/bin/glide-launch"
+          chmod +x "$out/bin/glide-launch"
+        '';
+    in
+    {
+      packages = forAllSystems (
+        pkgs:
+        let
+          unbundled = mkGlide pkgs;
+          glide = mkGlideBundle pkgs unbundled;
+        in
+        {
+          default = glide;
+          "glide-wm" = glide;
+          bundle = glide;
+          inherit unbundled;
+        }
+      );
+
+      apps = forAllSystems (pkgs: {
+        default = {
+          type = "app";
+          program = "${self.packages.${pkgs.stdenv.hostPlatform.system}.default}/bin/glide-launch";
+        };
+      });
+    };
+}


### PR DESCRIPTION
This adds a `flake.nix` so Glide can be built and run directly with Nix on macOS.

It exposes:
- `packages.<system>.default` as the app bundle
- `packages.<system>.bundle` as the same bundled output
- `packages.<system>.unbundled` for the raw binaries
- `apps.<system>.default` for `nix run`

## Motivation

I've been using Glide and have had a great experience with it.

I wanted a Nix-native way to build and install it, and I think it can also be useful for users who want to track upstream directly without depending on Homebrew cask update timing.

## Notes

This is an additive change for Nix users and does not change the existing Homebrew or manual installation paths.

For instance, https://github.com/openai/codex provides itself via `flake.nix`. Furthermore, Codex declaratively manages its development environment using a Nix mechanism called `devShells`, and we believe that incorporating `devShells` in the future would further improve the workflow.