### PR TITLE
fix: Emacs Mac windows should now be correctly managed

### DIFF
--- a/src/actor/app.rs
+++ b/src/actor/app.rs
@@ -23,11 +23,11 @@ use std::time::{Duration, Instant};
 use accessibility::{AXUIElement, AXUIElementActions, AXUIElementAttributes};
 use accessibility_sys::{
     kAXApplicationActivatedNotification, kAXApplicationDeactivatedNotification,
-    kAXErrorCannotComplete, kAXErrorNoValue, kAXMainWindowChangedNotification,
-    kAXStandardWindowSubrole, kAXTitleChangedNotification, kAXUIElementDestroyedNotification,
-    kAXWindowCreatedNotification, kAXWindowDeminiaturizedNotification,
-    kAXWindowMiniaturizedNotification, kAXWindowMovedNotification, kAXWindowResizedNotification,
-    kAXWindowRole,
+    kAXErrorCannotComplete, kAXErrorNoValue, kAXErrorNotificationAlreadyRegistered,
+    kAXMainWindowChangedNotification, kAXStandardWindowSubrole, kAXTitleChangedNotification,
+    kAXUIElementDestroyedNotification, kAXWindowCreatedNotification,
+    kAXWindowDeminiaturizedNotification, kAXWindowMiniaturizedNotification,
+    kAXWindowMovedNotification, kAXWindowResizedNotification, kAXWindowRole,
 };
 use core_foundation::runloop::CFRunLoop;
 use core_foundation::string::CFString;
@@ -365,10 +365,23 @@ impl State {
             true
         };
         for notif in APP_NOTIFICATIONS {
-            while let Err(err) = self.observer.add_notification(&self.app, notif) {
-                debug!(pid = ?self.pid, ?err, "Watching app for {notif} failed");
-                if !sleep() {
-                    return false;
+            loop {
+                match self.observer.add_notification(&self.app, notif) {
+                    Ok(()) => break,
+                    #[allow(non_upper_case_globals)]
+                    Err(accessibility::Error::Ax(kAXErrorNotificationAlreadyRegistered)) => {
+                        debug!(
+                            pid = ?self.pid,
+                            "Watching app for {notif} was already registered; continuing"
+                        );
+                        break;
+                    }
+                    Err(err) => {
+                        debug!(pid = ?self.pid, ?err, "Watching app for {notif} failed");
+                        if !sleep() {
+                            return false;
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
Glide wasn't picking up Emacs when it launched, and I tracked it down to Emacs not responding to the AX requests in time. I was happy to discover Glide already had retry logic, so I simply extended that to include Emacs as well.

The other commit is to have this logic consider a `kAXErrorNotificationAlreadyRegistered` a success.
I guess sometimes MacOS is able to register the listener but returns `kAXErrorCannotComplete` (Ax -25204) anyway?

Finally, what do you think about promoting the `debug!` into `warn!` in the failure case?
I think it's worth warning about, since if this doesn't complete then Glide will never correctly handle windows from the app in question.