### PR TITLE
feat: Add linear Next/Previous window navigation with wraparound

### DIFF
--- a/src/actor/layout.rs
+++ b/src/actor/layout.rs
@@ -114,9 +114,7 @@ impl LayoutCommand {
 
             NextLayout | PrevLayout | MoveFocus(_) | Ascend | Descend | Split(_)
             | ToggleFocusFloating | ToggleWindowFloating | ToggleFullscreen | ChangeLayoutKind
-            | FocusNext | FocusPrev => {
-                false
-            }
+            | FocusNext | FocusPrev => false,
         }
     }
 }

--- a/src/actor/layout.rs
+++ b/src/actor/layout.rs
@@ -49,6 +49,8 @@ pub enum LayoutCommand {
     CycleColumnWidth,
     ChangeLayoutKind,
     ToggleColumnTabbed,
+    FocusNext,
+    FocusPrev,
 }
 
 fn default_resize_percent() -> f64 {
@@ -111,7 +113,8 @@ impl LayoutCommand {
             | ToggleColumnTabbed => true,
 
             NextLayout | PrevLayout | MoveFocus(_) | Ascend | Descend | Split(_)
-            | ToggleFocusFloating | ToggleWindowFloating | ToggleFullscreen | ChangeLayoutKind => {
+            | ToggleFocusFloating | ToggleWindowFloating | ToggleFullscreen | ChangeLayoutKind
+            | FocusNext | FocusPrev => {
                 false
             }
         }
@@ -751,6 +754,22 @@ impl LayoutManager {
                 if new_focus.is_some() && is_scroll {
                     self.clear_user_scrolling(space);
                 }
+                let focus_window = new_focus.and_then(|new| self.tree.window_at(new));
+                let raise_windows = new_focus
+                    .map(|new| self.tree.select_returning_surfaced_windows(new))
+                    .unwrap_or_default();
+                EventResponse { focus_window, raise_windows }
+            }
+            LayoutCommand::FocusNext => {
+                let new_focus = self.tree.focus_next(layout, self.tree.selection(layout));
+                let focus_window = new_focus.and_then(|new| self.tree.window_at(new));
+                let raise_windows = new_focus
+                    .map(|new| self.tree.select_returning_surfaced_windows(new))
+                    .unwrap_or_default();
+                EventResponse { focus_window, raise_windows }
+            }
+            LayoutCommand::FocusPrev => {
+                let new_focus = self.tree.focus_prev(layout, self.tree.selection(layout));
                 let focus_window = new_focus.and_then(|new| self.tree.window_at(new));
                 let raise_windows = new_focus
                     .map(|new| self.tree.select_returning_surfaced_windows(new))
@@ -2079,6 +2098,53 @@ mod tests {
                 .focus_window,
             Some(WindowId::new(pid, 4))
         );
+    }
+
+    #[test]
+    fn focus_next_prev() {
+        use LayoutCommand::*;
+        use LayoutEvent::*;
+        let mut mgr = LayoutManager::new();
+        let space = SpaceId::new(1);
+        let pid = 1;
+
+        let screen = rect(0, 0, 1000, 1000);
+        _ = mgr.handle_event(SpaceExposed(space, screen.size));
+        _ = mgr.handle_event(WindowsOnScreenUpdated(
+            space,
+            pid,
+            vec![
+                (WindowId::new(pid, 1), win_info()),
+                (WindowId::new(pid, 2), win_info()),
+                (WindowId::new(pid, 3), win_info()),
+            ],
+        ));
+        _ = mgr.handle_event(WindowFocused(vec![space], WindowId::new(pid, 1)));
+
+        // Test FocusNext
+        assert_eq!(
+            mgr.handle_command(Some(space), &[space], FocusNext).focus_window,
+            Some(WindowId::new(pid, 2))
+        );
+        _ = mgr.handle_event(WindowFocused(vec![space], WindowId::new(pid, 2)));
+
+        assert_eq!(
+            mgr.handle_command(Some(space), &[space], FocusNext).focus_window,
+            Some(WindowId::new(pid, 3))
+        );
+        _ = mgr.handle_event(WindowFocused(vec![space], WindowId::new(pid, 3)));
+
+        assert_eq!(
+            mgr.handle_command(Some(space), &[space], FocusNext).focus_window,
+            Some(WindowId::new(pid, 1))
+        ); // wraparound
+        _ = mgr.handle_event(WindowFocused(vec![space], WindowId::new(pid, 1)));
+
+        // Test FocusPrev
+        assert_eq!(
+            mgr.handle_command(Some(space), &[space], FocusPrev).focus_window,
+            Some(WindowId::new(pid, 3))
+        ); // wraparound
     }
 
     #[test]

--- a/src/model/layout_tree.rs
+++ b/src/model/layout_tree.rs
@@ -415,6 +415,40 @@ impl LayoutTree {
         .last()
     }
 
+    pub fn focus_next(&self, layout: LayoutId, current: NodeId) -> Option<NodeId> {
+        let windows = self.windows_in_order(layout);
+        if windows.is_empty() {
+            return None;
+        }
+        let pos = windows.iter().position(|&n| n == current);
+        let next_pos = match pos {
+            Some(p) => (p + 1) % windows.len(),
+            None => 0,
+        };
+        Some(windows[next_pos])
+    }
+
+    pub fn focus_prev(&self, layout: LayoutId, current: NodeId) -> Option<NodeId> {
+        let windows = self.windows_in_order(layout);
+        if windows.is_empty() {
+            return None;
+        }
+        let pos = windows.iter().position(|&n| n == current);
+        let prev_pos = match pos {
+            Some(p) if p == 0 => windows.len() - 1,
+            Some(p) => p - 1,
+            None => windows.len() - 1,
+        };
+        Some(windows[prev_pos])
+    }
+
+    fn windows_in_order(&self, layout: LayoutId) -> Vec<NodeId> {
+        self.root(layout)
+            .traverse_preorder(self.map())
+            .filter(|&node| self.window_at(node).is_some())
+            .collect()
+    }
+
     pub fn traverse_scroll_wrapping(
         &self,
         layout: LayoutId,
@@ -981,6 +1015,50 @@ mod tests {
         assert_eq!(None, tree.window_at(b3));
         assert_eq!(None, tree.window_at(a3));
         assert_eq!(2, root.children(tree.map()).count());
+    }
+
+    #[test]
+    fn focus_next_prev_with_wraparound() {
+        let mut tree = LayoutTree::new();
+        let layout = tree.create_layout();
+        let root = tree.root(layout);
+        let n1 = tree.add_window_under(layout, root, WindowId::new(1, 1));
+        let n2 = tree.add_window_under(layout, root, WindowId::new(1, 2));
+        let n3 = tree.add_window_under(layout, root, WindowId::new(1, 3));
+
+        // Test next
+        assert_eq!(tree.focus_next(layout, n1), Some(n2));
+        assert_eq!(tree.focus_next(layout, n2), Some(n3));
+        assert_eq!(tree.focus_next(layout, n3), Some(n1)); // wraparound
+
+        // Test prev
+        assert_eq!(tree.focus_prev(layout, n3), Some(n2));
+        assert_eq!(tree.focus_prev(layout, n2), Some(n1));
+        assert_eq!(tree.focus_prev(layout, n1), Some(n3)); // wraparound
+
+        // Test with container selection
+        assert_eq!(tree.focus_next(layout, root), Some(n1));
+        assert_eq!(tree.focus_prev(layout, root), Some(n3));
+    }
+
+    #[test]
+    fn focus_next_prev_nested() {
+        let mut tree = LayoutTree::new();
+        let layout = tree.create_layout();
+        let root = tree.root(layout);
+        let n1 = tree.add_window_under(layout, root, WindowId::new(1, 1));
+        let c1 = tree.add_container(root, ContainerKind::Vertical);
+        let n2 = tree.add_window_under(layout, c1, WindowId::new(1, 2));
+        let n3 = tree.add_window_under(layout, c1, WindowId::new(1, 3));
+
+        // Order should be n1, n2, n3 (pre-order)
+        assert_eq!(tree.focus_next(layout, n1), Some(n2));
+        assert_eq!(tree.focus_next(layout, n2), Some(n3));
+        assert_eq!(tree.focus_next(layout, n3), Some(n1));
+
+        assert_eq!(tree.focus_prev(layout, n1), Some(n3));
+        assert_eq!(tree.focus_prev(layout, n3), Some(n2));
+        assert_eq!(tree.focus_prev(layout, n2), Some(n1));
     }
 
     #[test]


### PR DESCRIPTION
- Add 'focus_next' and 'focus_prev' commands to LayoutManager.
- Implement 'focus_next' and 'focus_prev' in LayoutTree using pre-order traversal.
- Add wraparound logic for both commands at the space-level.
- Add unit and integration tests for new navigation logic.

Fixes #180 