### PR TITLE
improve: Start animations immediately instead of running them in series

### DIFF
--- a/src/actor/app.rs
+++ b/src/actor/app.rs
@@ -185,14 +185,15 @@ struct State {
     last_activated: Option<(Instant, Quiet, Option<WindowId>, oneshot::Sender<()>)>,
     is_frontmost: bool,
     raises_tx: Sender<(Span, RaiseRequest)>,
-    is_animating: bool,
-    enable_enhanced_ui_after_animating: bool,
+    active_window_animations: u32,
+    restore_enhanced_ui_on_last_end: bool,
 }
 
 struct WindowState {
     elem: AXUIElement,
     is_standard: bool,
     last_seen_txid: TransactionId,
+    is_animating: bool,
     /// The last frame requested via [`Request::SetWindowFrame`] during an animation.
     /// Used to apply a deferred full-frame fixup in [`Request::EndWindowAnimation`].
     last_animation_frame: Option<CGRect>,
@@ -469,11 +470,11 @@ impl State {
                 });
             }
             &mut Request::SetWindowPos(wid, pos, txid) => {
-                let is_animating = self.is_animating;
+                let app_is_animating = self.active_window_animations > 0;
                 let app_elem = &self.app.clone();
                 let window = self.window_mut(wid)?;
                 window.last_seen_txid = txid;
-                without_enhanced(is_animating, app_elem, || {
+                without_enhanced(app_is_animating, app_elem, || {
                     trace("set_position", &window.elem, || {
                         window.elem.set_position(pos.to_cgtype())
                     })
@@ -490,15 +491,15 @@ impl State {
                 ));
             }
             &mut Request::SetWindowFrame(wid, frame, txid) => {
-                let is_animating = self.is_animating;
+                let app_is_animating = self.active_window_animations > 0;
                 let app_elem = &self.app.clone();
                 let window = self.window_mut(wid)?;
                 window.last_seen_txid = txid;
-                if is_animating {
+                if window.is_animating {
                     window.last_animation_frame = Some(frame);
                 }
-                without_enhanced(is_animating, app_elem, || {
-                    if is_animating {
+                without_enhanced(app_is_animating, app_elem, || {
+                    if window.is_animating {
                         set_window_frame_once(&window.elem, frame)?;
                     } else {
                         set_window_frame_with_retries(&window.elem, frame)?;
@@ -515,41 +516,60 @@ impl State {
                 ));
             }
             &mut Request::BeginWindowAnimation(wid) => {
-                self.enable_enhanced_ui_after_animating =
-                    match trace("enhanced_user_interface", &self.app, || {
-                        self.app.enhanced_user_interface()
-                    }) {
-                        Ok(enabled) => enabled,
-                        Err(_) => false,
-                    };
-                if self.enable_enhanced_ui_after_animating {
-                    _ = trace("set_enhanced_user_interface", &self.app, || {
-                        self.app.set_enhanced_user_interface(false)
-                    });
+                self.active_window_animations += 1;
+                if self.active_window_animations == 1 {
+                    self.restore_enhanced_ui_on_last_end =
+                        match trace("enhanced_user_interface", &self.app, || {
+                            self.app.enhanced_user_interface()
+                        }) {
+                            Ok(enabled) => enabled,
+                            Err(_) => false,
+                        };
+                    if self.restore_enhanced_ui_on_last_end {
+                        _ = trace("set_enhanced_user_interface", &self.app, || {
+                            self.app.set_enhanced_user_interface(false)
+                        });
+                    }
                 }
                 let window = self.window_mut(wid)?;
+                window.is_animating = true;
                 window.last_animation_frame = None;
                 let elem = window.elem.clone();
                 self.stop_notifications_for_animation(&elem);
-                self.is_animating = true;
             }
             &mut Request::EndWindowAnimation(wid) => {
-                let window = self.window_mut(wid)?;
+                let remaining_animations = if self.active_window_animations == 0 {
+                    warn!(?wid, "Got EndWindowAnimation without a matching begin");
+                    0
+                } else {
+                    self.active_window_animations -= 1;
+                    self.active_window_animations
+                };
+                let Ok(window) = self.window_mut(wid) else {
+                    if remaining_animations == 0 && self.restore_enhanced_ui_on_last_end {
+                        _ = trace("set_enhanced_user_interface", &self.app, || {
+                            self.app.set_enhanced_user_interface(true)
+                        });
+                        self.restore_enhanced_ui_on_last_end = false;
+                    }
+                    return Ok(false);
+                };
+                window.is_animating = false;
                 let last_animation_frame = window.last_animation_frame.take();
                 let elem = window.elem.clone();
                 let last_seen_txid = window.last_seen_txid;
                 // Apply the deferred full-frame fixup while enhanced UI is still
-                // disabled and before restarting notifications, so retries don't
-                // fire spurious AX move/resize notifications.
+                // disabled and before restarting notifications.
                 if let Some(frame) = last_animation_frame {
                     if let Err(e) = set_window_frame_with_retries(&elem, frame) {
                         warn!("Failed to apply frame fixup after animation: {e}");
                     }
                 }
-                if self.enable_enhanced_ui_after_animating {
+                if remaining_animations == 0 && self.restore_enhanced_ui_on_last_end {
                     _ = trace("set_enhanced_user_interface", &self.app, || {
                         self.app.set_enhanced_user_interface(true)
                     });
+                    self.restore_enhanced_ui_on_last_end = false;
                 }
                 self.restart_notifications_after_animation(&elem);
                 let frame = trace("frame", &elem, || elem.frame())?;
@@ -560,7 +580,6 @@ impl State {
                     Requested(true),
                     None,
                 ));
-                self.is_animating = false;
             }
             &mut Request::Raise(ref wids, ref token, sequence_id, quiet) => {
                 self.raises_tx
@@ -984,6 +1003,7 @@ impl State {
                 elem,
                 last_seen_txid: TransactionId::default(),
                 is_standard: info.is_standard,
+                is_animating: false,
                 last_animation_frame: None,
             },
         );
@@ -1122,8 +1142,8 @@ fn app_thread_main(
         last_activated: None,
         is_frontmost: false,
         raises_tx,
-        is_animating: false,
-        enable_enhanced_ui_after_animating: false,
+        active_window_animations: 0,
+        restore_enhanced_ui_on_last_end: false,
     };
 
     Executor::run(state.run(

--- a/src/actor/raise.rs
+++ b/src/actor/raise.rs
@@ -174,7 +174,18 @@ impl RaiseManager {
                             sequence_id, sequence.pending_raises
                         );
                         sequence.pending_raises.clear();
+                        // Cancel the raises that hung, then install a fresh
+                        // token. The focus raise is sent next (in
+                        // process_active_sequence) and must use a live token, or
+                        // the app rejects it as cancelled and never reports
+                        // completion, blocking the manager permanently.
                         sequence.raise_token.cancel();
+                        sequence.raise_token = CancellationToken::new();
+                        // Restart the timeout window so the focus phase gets its
+                        // own timeout. Otherwise a hung focus raise could never
+                        // time out again and would block all future raises.
+                        sequence.started_at = Instant::now();
+                        sequence.timed_out = false;
                     }
                 }
             }
@@ -573,6 +584,53 @@ mod tests {
             });
 
             // Verify that the sequence was completed and removed
+            assert!(raise_manager.active_sequence.is_none());
+        });
+    }
+
+    #[test]
+    fn test_timeout_focus_raise_uses_live_token() {
+        Executor::run(async {
+            let mut raise_manager = RaiseManager::new();
+            let (app_handles, mut app_rx) = create_test_app_handles();
+
+            let layout_msg = create_layout_response(
+                vec![WindowId::new(1, 1)],
+                Some((WindowId::new(1, 2), None)),
+                app_handles,
+            );
+            raise_manager.handle_message(layout_msg);
+
+            // Time out the regular raise. This cancels the sequence's token, but
+            // the focus raise sent afterward must use a live token; otherwise the
+            // app rejects it as cancelled and never reports completion, blocking
+            // the manager forever.
+            raise_manager.handle_message(Event::RaiseTimeout { sequence_id: 1 });
+
+            let requests = collect_requests(&mut app_rx);
+            let focus_token = requests
+                .iter()
+                .find_map(|r| match r {
+                    Request::Raise(wids, token, _, Quiet::No)
+                        if *wids == vec![WindowId::new(1, 2)] =>
+                    {
+                        Some(token.clone())
+                    }
+                    _ => None,
+                })
+                .expect("focus raise should have been sent after timeout");
+            assert!(
+                !focus_token.is_cancelled(),
+                "focus raise must use a live token after a timeout"
+            );
+
+            // The sequence should still be waiting on the focus raise so it can
+            // complete normally.
+            assert!(raise_manager.active_sequence.is_some());
+            raise_manager.handle_message(Event::RaiseCompleted {
+                window_id: WindowId::new(1, 2),
+                sequence_id: 1,
+            });
             assert!(raise_manager.active_sequence.is_none());
         });
     }

--- a/src/actor/reactor.rs
+++ b/src/actor/reactor.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use std::{mem, thread};
 
-use animation::Animation;
+use animation::{Animation, AnimationManager, Message as AnimationMessage};
 use main_window::MainWindowTracker;
 use objc2_core_foundation::CGRect;
 use redact::Secret;
@@ -218,6 +218,7 @@ pub struct Reactor {
     in_drag: bool,
     record: Record,
     raise_manager_tx: raise::Sender,
+    animation_tx: Option<animation::Sender>,
     mouse_tx: Option<mouse::Sender>,
     status_tx: Option<status::Sender>,
     group_indicators_tx: group_bars::Sender,
@@ -352,6 +353,7 @@ impl Reactor {
             in_drag: false,
             record,
             raise_manager_tx,
+            animation_tx: None,
             mouse_tx: None,
             status_tx: None,
             group_indicators_tx: group_indicators_tx,
@@ -361,12 +363,15 @@ impl Reactor {
     pub async fn run(mut self, events: Receiver, events_tx: Sender) {
         let (raise_manager_tx, raise_manager_rx) = mpsc::unbounded_channel();
         self.raise_manager_tx = raise_manager_tx.clone();
+        let (animation_tx, animation_rx) = mpsc::unbounded_channel();
+        self.animation_tx = Some(animation_tx);
 
         let mouse_tx = self.mouse_tx.clone();
         let reactor_task = self.run_reactor_loop(events);
         let raise_manager_task = RaiseManager::run(raise_manager_rx, events_tx, mouse_tx);
+        let animation_task = AnimationManager::run(animation_rx);
 
-        let _ = tokio::join!(reactor_task, raise_manager_task);
+        let _ = tokio::join!(reactor_task, raise_manager_task, animation_task);
     }
 
     async fn run_reactor_loop(mut self, mut events: Receiver) {
@@ -1089,10 +1094,25 @@ impl Reactor {
         }
         // If the user is doing something with the mouse we don't want to
         // animate on top of that.
-        if skip_anim || !self.config.settings.animate || self.layout.has_active_scroll_animation() {
-            anim.skip_to_end();
+        let skip_anim =
+            skip_anim || !self.config.settings.animate || self.layout.has_active_scroll_animation();
+        if let Some(tx) = &self.animation_tx
+            && !anim.is_empty()
+        {
+            let message = if skip_anim {
+                AnimationMessage::SkipToEnd(anim)
+            } else {
+                AnimationMessage::Replace(anim)
+            };
+            if let Err(err) = tx.send(message) {
+                error!("Animation manager exited unexpectedly");
+                match err.0 {
+                    AnimationMessage::Replace(animation) => animation.skip_to_end(),
+                    AnimationMessage::SkipToEnd(animation) => animation.skip_to_end(),
+                }
+            }
         } else {
-            anim.run();
+            anim.skip_to_end();
         }
     }
 }
@@ -1138,6 +1158,31 @@ pub mod tests {
             requests.is_empty(),
             "got requests when there should have been none: {requests:?}"
         );
+    }
+
+    #[test]
+    fn it_sends_layout_animation_to_manager() {
+        let mut apps = Apps::new();
+        let (mut reactor, mut animation_rx) =
+            Reactor::new_for_test_with_animation(LayoutManager::new(), true);
+        reactor.handle_event(Event::ScreenParametersChanged {
+            frames: vec![CGRect::new(CGPoint::new(0., 0.), CGSize::new(1000., 1000.))],
+            spaces: vec![Some(SpaceId::new(1))],
+            scale_factors: vec![2.0],
+            converter: CoordinateConverter::default(),
+        });
+
+        reactor.handle_events(apps.make_app(1, make_windows(2)));
+        reactor.handle_event(Event::StartupComplete);
+
+        assert!(
+            apps.requests().is_empty(),
+            "layout should be handed to the animation manager, not sent directly to app actors"
+        );
+        assert!(matches!(
+            animation_rx.try_recv(),
+            Ok(animation::Message::Replace(_))
+        ));
     }
 
     #[test]

--- a/src/actor/reactor/animation.rs
+++ b/src/actor/reactor/animation.rs
@@ -1,41 +1,182 @@
 // Copyright The Glide Authors
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use std::thread;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use objc2_core_foundation::{CGPoint, CGRect, CGSize};
+use tokio::sync::mpsc;
 
 use super::TransactionId;
 use crate::actor::app::{AppThreadHandle, Request, WindowId};
+use crate::sys::timer::Timer;
+
+pub type Sender = mpsc::UnboundedSender<Message>;
+pub type Receiver = mpsc::UnboundedReceiver<Message>;
 
 #[derive(Debug)]
-pub struct Animation<'a> {
-    //start: CFAbsoluteTime,
-    //interval: CFTimeInterval,
-    start: Instant,
-    interval: Duration,
-    frames: u32,
-
-    windows: Vec<(
-        &'a AppThreadHandle,
-        WindowId,
-        CGRect,
-        CGRect,
-        bool,
-        TransactionId,
-    )>,
+pub enum Message {
+    Replace(Animation),
+    SkipToEnd(Animation),
 }
 
-impl<'a> Animation<'a> {
+#[derive(Debug, Default)]
+pub struct AnimationManager {
+    active: Option<ActiveAnimation>,
+}
+
+#[derive(Debug)]
+struct ActiveAnimation {
+    animation: Animation,
+    next_frame: u32,
+}
+
+#[derive(Debug)]
+pub struct Animation {
+    interval: Duration,
+    frames: u32,
+    windows: Vec<AnimatedWindow>,
+}
+
+#[derive(Debug)]
+struct AnimatedWindow {
+    handle: AppThreadHandle,
+    wid: WindowId,
+    start: CGRect,
+    finish: CGRect,
+    is_focus: bool,
+    txid: TransactionId,
+}
+
+impl AnimatedWindow {
+    fn frame_after(&self, frame: u32, total_frames: u32) -> CGRect {
+        if frame == 0 {
+            return if self.is_focus {
+                CGRect {
+                    origin: self.start.origin,
+                    size: self.finish.size,
+                }
+            } else {
+                self.start
+            };
+        }
+
+        let t = f64::from(frame) / f64::from(total_frames);
+        let mut rect = get_frame(self.start, self.finish, t);
+        if self.is_focus || frame * 2 >= total_frames {
+            rect.size = self.finish.size;
+        } else {
+            rect.size = self.start.size;
+        }
+        rect
+    }
+}
+
+impl AnimationManager {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub async fn run(mut rx: Receiver) {
+        let mut manager = Self::new();
+        let mut tick_timer = Timer::manual();
+
+        loop {
+            tokio::select! {
+                message = rx.recv() => {
+                    let Some(message) = message else {
+                        manager.finish_active();
+                        break;
+                    };
+                    if let Some(delay) = manager.handle_message(message) {
+                        tick_timer.set_next_fire(delay);
+                    }
+                }
+                _ = tick_timer.next(), if manager.active.is_some() => {
+                    if let Some(delay) = manager.tick() {
+                        tick_timer.set_next_fire(delay);
+                    }
+                }
+            }
+        }
+    }
+
+    pub fn handle_message(&mut self, message: Message) -> Option<Duration> {
+        match message {
+            Message::Replace(animation) => {
+                self.active = match self.active.take() {
+                    Some(active) => Some(active.replace_with(animation)),
+                    None => ActiveAnimation::start(animation),
+                };
+                self.active.as_ref().map(|active| active.animation.interval)
+            }
+            Message::SkipToEnd(animation) => {
+                self.finish_active();
+                animation.skip_to_end();
+                None
+            }
+        }
+    }
+
+    pub fn tick(&mut self) -> Option<Duration> {
+        let active = self.active.as_mut()?;
+        active.send_next_frame();
+        if active.is_complete() {
+            let active = self.active.take().expect("animation disappeared while ticking");
+            active.animation.end();
+            None
+        } else {
+            Some(active.animation.interval)
+        }
+    }
+
+    fn finish_active(&mut self) {
+        if let Some(active) = self.active.take() {
+            active.animation.skip_to_end_and_end();
+        }
+    }
+}
+
+impl ActiveAnimation {
+    fn start(animation: Animation) -> Option<Self> {
+        if animation.is_empty() {
+            return None;
+        }
+        animation.begin();
+        Some(Self { animation, next_frame: 1 })
+    }
+
+    fn replace_with(self, mut next: Animation) -> Self {
+        let continuing = next.patch_starts_from(self.current_frames());
+        next.begin_windows_not_in(&continuing);
+        self.animation.finish_windows_not_in(&continuing);
+        Self { animation: next, next_frame: 1 }
+    }
+
+    fn send_next_frame(&mut self) {
+        self.animation.send_frame(self.next_frame);
+        self.next_frame += 1;
+    }
+
+    fn is_complete(&self) -> bool {
+        self.next_frame > self.animation.frames
+    }
+
+    fn current_frames(&self) -> Vec<(WindowId, CGRect)> {
+        let frame = self.next_frame.saturating_sub(1);
+        self.animation
+            .windows
+            .iter()
+            .map(|window| (window.wid, window.frame_after(frame, self.animation.frames)))
+            .collect()
+    }
+}
+
+impl Animation {
     pub fn new() -> Self {
         const FPS: f64 = 100.0;
         const DURATION: f64 = 0.30;
         let interval = Duration::from_secs_f64(1.0 / FPS);
-        // let now = unsafe { CFAbsoluteTimeGetCurrent() };
-        let now = Instant::now();
         Animation {
-            start: now, // + interval, // not necessary, provide one extra frame to get things going
             interval,
             frames: (DURATION * FPS).round() as u32,
             windows: vec![],
@@ -44,73 +185,104 @@ impl<'a> Animation<'a> {
 
     pub fn add_window(
         &mut self,
-        handle: &'a AppThreadHandle,
+        handle: &AppThreadHandle,
         wid: WindowId,
         start: CGRect,
         finish: CGRect,
         is_focus: bool,
         txid: TransactionId,
     ) {
-        self.windows.push((handle, wid, start, finish, is_focus, txid))
+        self.windows.push(AnimatedWindow {
+            handle: handle.clone(),
+            wid,
+            start,
+            finish,
+            is_focus,
+            txid,
+        });
     }
 
-    pub fn run(self) {
+    pub fn skip_to_end(&self) {
+        for window in &self.windows {
+            _ = window
+                .handle
+                .send(Request::SetWindowFrame(window.wid, window.finish, window.txid));
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.windows.is_empty()
+    }
+
+    fn begin(&self) {
+        self.begin_windows_not_in(&[]);
+    }
+
+    fn begin_windows_not_in(&self, skip: &[WindowId]) {
+        for window in &self.windows {
+            if skip.contains(&window.wid) {
+                continue;
+            }
+            _ = window.handle.send(Request::BeginWindowAnimation(window.wid));
+            if window.is_focus {
+                let frame = CGRect {
+                    origin: window.start.origin,
+                    size: window.finish.size,
+                };
+                _ = window.handle.send(Request::SetWindowFrame(window.wid, frame, window.txid));
+            }
+        }
+    }
+
+    fn finish_windows_not_in(&self, keep: &[WindowId]) {
+        for window in &self.windows {
+            if keep.contains(&window.wid) {
+                continue;
+            }
+            _ = window
+                .handle
+                .send(Request::SetWindowFrame(window.wid, window.finish, window.txid));
+            _ = window.handle.send(Request::EndWindowAnimation(window.wid));
+        }
+    }
+
+    fn send_frame(&self, frame: u32) {
+        let t = f64::from(frame) / f64::from(self.frames);
+        for window in &self.windows {
+            let mut rect = get_frame(window.start, window.finish, t);
+            if frame * 2 == self.frames || frame == self.frames {
+                rect.size = window.finish.size;
+                _ = window.handle.send(Request::SetWindowFrame(window.wid, rect, window.txid));
+            } else {
+                _ = window.handle.send(Request::SetWindowPos(window.wid, rect.origin, window.txid));
+            }
+        }
+    }
+
+    fn end(&self) {
+        for window in &self.windows {
+            _ = window.handle.send(Request::EndWindowAnimation(window.wid));
+        }
+    }
+
+    fn patch_starts_from(&mut self, current_frames: Vec<(WindowId, CGRect)>) -> Vec<WindowId> {
+        let mut continuing = Vec::new();
+        for (wid, current_frame) in current_frames {
+            let Some(window) = self.windows.iter_mut().find(|window| window.wid == wid) else {
+                continue;
+            };
+            window.start = current_frame;
+            continuing.push(wid);
+        }
+        continuing
+    }
+
+    fn skip_to_end_and_end(self) {
         if self.windows.is_empty() {
             return;
         }
-
-        for &(handle, wid, from, to, is_focus, txid) in &self.windows {
-            _ = handle.send(Request::BeginWindowAnimation(wid));
-            // Resize new windows immediately.
-            if is_focus {
-                let frame = CGRect {
-                    origin: from.origin,
-                    size: to.size,
-                };
-                _ = handle.send(Request::SetWindowFrame(wid, frame, txid));
-            }
-        }
-
-        let mut next_frames = Vec::with_capacity(self.windows.len());
-        for frame in 1..=self.frames {
-            let t: f64 = f64::from(frame) / f64::from(self.frames);
-
-            next_frames.clear();
-            for (_, _, from, to, _, _) in &self.windows {
-                next_frames.push(get_frame(*from, *to, t));
-            }
-
-            let deadline = self.start + frame * self.interval;
-            let duration = deadline - Instant::now();
-            if duration < Duration::ZERO {
-                continue;
-            }
-            thread::sleep(duration);
-
-            for (&(handle, wid, _, to, _, txid), rect) in self.windows.iter().zip(&next_frames) {
-                let mut rect = *rect;
-                // Actually don't animate size, too slow. Resize halfway through
-                // and then set the size again at the end, in case it got
-                // clipped during the animation.
-                if frame * 2 == self.frames || frame == self.frames {
-                    rect.size = to.size;
-                    _ = handle.send(Request::SetWindowFrame(wid, rect, txid));
-                } else {
-                    _ = handle.send(Request::SetWindowPos(wid, rect.origin, txid));
-                }
-            }
-        }
-
-        for &(handle, wid, ..) in &self.windows {
-            _ = handle.send(Request::EndWindowAnimation(wid));
-        }
-    }
-
-    #[allow(dead_code)]
-    pub fn skip_to_end(self) {
-        for &(handle, wid, _from, to, _, txid) in &self.windows {
-            _ = handle.send(Request::SetWindowFrame(wid, to, txid));
-        }
+        self.skip_to_end();
+        self.end();
     }
 }
 
@@ -138,4 +310,178 @@ fn ease(t: f64) -> f64 {
 
 fn blend(a: f64, b: f64, s: f64) -> f64 {
     (1.0 - s) * a + s * b
+}
+
+#[cfg(test)]
+mod tests {
+    use objc2_core_foundation::{CGPoint, CGSize};
+    use tokio::sync::mpsc::unbounded_channel;
+
+    use super::*;
+
+    fn rect(origin_x: f64, origin_y: f64, width: f64, height: f64) -> CGRect {
+        CGRect::new(CGPoint::new(origin_x, origin_y), CGSize::new(width, height))
+    }
+
+    fn animation(handle: &AppThreadHandle, wid: WindowId, from: CGRect, to: CGRect) -> Animation {
+        let mut animation = Animation::new();
+        animation.add_window(handle, wid, from, to, false, TransactionId::default());
+        animation
+    }
+
+    fn collect_requests(
+        rx: &mut mpsc::UnboundedReceiver<(tracing::Span, Request)>,
+    ) -> Vec<Request> {
+        let mut requests = Vec::new();
+        while let Ok((_, request)) = rx.try_recv() {
+            requests.push(request);
+        }
+        requests
+    }
+
+    fn assert_set_window_frame(request: &Request, wid: WindowId, frame: CGRect) {
+        match request {
+            Request::SetWindowFrame(req_wid, req_frame, txid) => {
+                assert_eq!(*req_wid, wid);
+                assert_eq!(*req_frame, frame);
+                assert_eq!(*txid, TransactionId::default());
+            }
+            _ => panic!("expected SetWindowFrame, got {request:?}"),
+        }
+    }
+
+    fn assert_set_window_pos(request: &Request, wid: WindowId, pos: CGPoint) {
+        match request {
+            Request::SetWindowPos(req_wid, req_pos, txid) => {
+                assert_eq!(*req_wid, wid);
+                assert_eq!(*req_pos, pos);
+                assert_eq!(*txid, TransactionId::default());
+            }
+            _ => panic!("expected SetWindowPos, got {request:?}"),
+        }
+    }
+
+    #[test]
+    fn replacement_uses_last_animated_frame_for_continuing_windows() {
+        let (tx, mut rx) = unbounded_channel();
+        let handle = AppThreadHandle::new_for_test(tx);
+        let wid = WindowId::new(1, 1);
+        let first = animation(
+            &handle,
+            wid,
+            rect(0.0, 0.0, 10.0, 10.0),
+            rect(50.0, 60.0, 10.0, 10.0),
+        );
+        let second = animation(
+            &handle,
+            wid,
+            rect(50.0, 60.0, 10.0, 10.0),
+            rect(80.0, 90.0, 10.0, 10.0),
+        );
+
+        let mut manager = AnimationManager::new();
+        manager.handle_message(Message::Replace(first));
+        assert!(matches!(
+            collect_requests(&mut rx).as_slice(),
+            [Request::BeginWindowAnimation(req_wid)] if *req_wid == wid
+        ));
+
+        manager.tick();
+        let continuing_frame = manager.active.as_ref().unwrap().current_frames()[0].1;
+        assert_set_window_pos(&collect_requests(&mut rx)[0], wid, continuing_frame.origin);
+
+        manager.handle_message(Message::Replace(second));
+        assert!(collect_requests(&mut rx).is_empty());
+
+        let resumed_start = manager.active.as_ref().unwrap().animation.windows[0].start;
+        assert_eq!(resumed_start, continuing_frame);
+
+        manager.tick();
+        let expected_next = get_frame(resumed_start, rect(80.0, 90.0, 10.0, 10.0), 1.0 / 30.0);
+        assert_set_window_pos(&collect_requests(&mut rx)[0], wid, expected_next.origin);
+    }
+
+    #[test]
+    fn replacement_only_restarts_changed_windows() {
+        let (tx, mut rx) = unbounded_channel();
+        let handle = AppThreadHandle::new_for_test(tx);
+        let wid1 = WindowId::new(1, 1);
+        let wid2 = WindowId::new(1, 2);
+        let wid3 = WindowId::new(1, 3);
+        let mut first = Animation::new();
+        first.add_window(
+            &handle,
+            wid1,
+            rect(0.0, 0.0, 10.0, 10.0),
+            rect(50.0, 60.0, 10.0, 10.0),
+            false,
+            TransactionId::default(),
+        );
+        first.add_window(
+            &handle,
+            wid2,
+            rect(10.0, 0.0, 10.0, 10.0),
+            rect(60.0, 60.0, 10.0, 10.0),
+            false,
+            TransactionId::default(),
+        );
+        let mut second = Animation::new();
+        second.add_window(
+            &handle,
+            wid1,
+            rect(50.0, 60.0, 10.0, 10.0),
+            rect(80.0, 90.0, 10.0, 10.0),
+            false,
+            TransactionId::default(),
+        );
+        second.add_window(
+            &handle,
+            wid3,
+            rect(20.0, 0.0, 10.0, 10.0),
+            rect(90.0, 90.0, 10.0, 10.0),
+            false,
+            TransactionId::default(),
+        );
+
+        let mut manager = AnimationManager::new();
+        manager.handle_message(Message::Replace(first));
+        assert_eq!(collect_requests(&mut rx).len(), 2);
+        manager.handle_message(Message::Replace(second));
+
+        let requests = collect_requests(&mut rx);
+        assert_eq!(requests.len(), 3);
+        assert!(matches!(requests[0], Request::BeginWindowAnimation(req_wid) if req_wid == wid3));
+        assert_set_window_frame(&requests[1], wid2, rect(60.0, 60.0, 10.0, 10.0));
+        assert!(matches!(requests[2], Request::EndWindowAnimation(req_wid) if req_wid == wid2));
+    }
+
+    #[test]
+    fn skip_to_end_finishes_active_animation_and_applies_new_layout() {
+        let (tx, mut rx) = unbounded_channel();
+        let handle = AppThreadHandle::new_for_test(tx);
+        let wid = WindowId::new(1, 1);
+        let first = animation(
+            &handle,
+            wid,
+            rect(0.0, 0.0, 10.0, 10.0),
+            rect(50.0, 60.0, 10.0, 10.0),
+        );
+        let second = animation(
+            &handle,
+            wid,
+            rect(50.0, 60.0, 10.0, 10.0),
+            rect(80.0, 90.0, 10.0, 10.0),
+        );
+
+        let mut manager = AnimationManager::new();
+        manager.handle_message(Message::Replace(first));
+        manager.handle_message(Message::SkipToEnd(second));
+
+        let requests = collect_requests(&mut rx);
+        assert_eq!(requests.len(), 4);
+        assert!(matches!(requests[0], Request::BeginWindowAnimation(req_wid) if req_wid == wid));
+        assert_set_window_frame(&requests[1], wid, rect(50.0, 60.0, 10.0, 10.0));
+        assert!(matches!(requests[2], Request::EndWindowAnimation(req_wid) if req_wid == wid));
+        assert_set_window_frame(&requests[3], wid, rect(80.0, 90.0, 10.0, 10.0));
+    }
 }

--- a/src/actor/reactor/testing.rs
+++ b/src/actor/reactor/testing.rs
@@ -10,7 +10,7 @@ use objc2_core_foundation::{CGPoint, CGRect, CGSize};
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel};
 use tracing::{Span, debug, info};
 
-use super::{Event, Reactor, Record, Requested, TransactionId};
+use super::{Event, Reactor, Record, Requested, TransactionId, animation};
 use crate::actor::app::{AppThreadHandle, Request, WindowId};
 use crate::actor::layout::LayoutManager;
 use crate::actor::reactor;
@@ -27,6 +27,21 @@ impl Reactor {
         let record = Record::new_for_test(tempfile::NamedTempFile::new().unwrap());
         let (group_indicators_tx, _) = crate::actor::channel();
         Reactor::new(Arc::new(config), layout, record, group_indicators_tx)
+    }
+
+    pub fn new_for_test_with_animation(
+        layout: LayoutManager,
+        animate: bool,
+    ) -> (Reactor, tokio::sync::mpsc::UnboundedReceiver<animation::Message>) {
+        let mut config = Config::default();
+        config.settings.default_disable = false;
+        config.settings.animate = animate;
+        let record = Record::new_for_test(tempfile::NamedTempFile::new().unwrap());
+        let (group_indicators_tx, _) = crate::actor::channel();
+        let mut reactor = Reactor::new(Arc::new(config), layout, record, group_indicators_tx);
+        let (tx, rx) = unbounded_channel();
+        reactor.animation_tx = Some(tx);
+        (reactor, rx)
     }
 
     pub fn handle_events(&mut self, events: Vec<Event>) {


### PR DESCRIPTION
- **refactor: make app animation state refcounted**
- **refactor: extract replaceable animation manager**
- **feat: run layout animations asynchronously**
