### PR TITLE
Add pause and resume commands

### DIFF
--- a/glide.default.toml
+++ b/glide.default.toml
@@ -62,6 +62,22 @@ default_keys = false
 #
 # For a comprehensive list of key names, see:
 # https://docs.rs/livesplit-hotkey/0.8.0/livesplit_hotkey/enum.KeyCode.html
+#
+# In addition to the commands bound below, you can also bind the following commands:
+#
+# Toggle glide on/off:
+# "<key>": "toggle_global_enabled"
+#
+# Set glide on/off:
+# "<key>": { "set_global_enabled" = { "enabled" = <bool> } }
+#
+# Focus the next/previous window:
+# "<key>": "focus_next"
+# "<key>": "focus_prev"
+#
+# Developer commands (print debug info to the logs):
+# "<key>": "show_timings"
+# "<key>": "serialize"
 
 # Save the current state to the restore file and exit.
 # Restore this with the --restore option when starting glide.

--- a/src/actor/server.rs
+++ b/src/actor/server.rs
@@ -24,6 +24,8 @@ pub enum Request {
     Ping(String),
     UpdateConfig(Config),
     Service(ServiceRequest),
+    /// Pause (false) or resume (true) global window management.
+    SetEnabled(bool),
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -99,6 +101,15 @@ impl State {
                 _ = self.wm_tx.send((
                     Span::current(),
                     wm_controller::WmEvent::ConfigUpdated(Arc::new(config)),
+                ));
+                Response::Success
+            }
+            Request::SetEnabled(enabled) => {
+                _ = self.wm_tx.send((
+                    Span::current(),
+                    wm_controller::WmEvent::Command(wm_controller::WmCommand::Wm(
+                        wm_controller::WmCmd::SetGlobalEnabled(enabled),
+                    )),
                 ));
                 Response::Success
             }

--- a/src/actor/space_manager.rs
+++ b/src/actor/space_manager.rs
@@ -36,6 +36,7 @@ pub enum Event {
     FocusedScreenChanged(ScreenId),
     ToggleSpace(ScreenId),
     ToggleGlobalEnabled,
+    SetGlobalEnabled(bool),
     LoginWindowActive(bool),
     ExposeActive(bool),
     ReactorCommand(reactor::Command),
@@ -172,14 +173,10 @@ impl SpaceManager {
                 self.request_space_refresh();
             }
             Event::ToggleGlobalEnabled => {
-                self.is_globally_enabled = !self.is_globally_enabled;
-                if !self.is_globally_enabled {
-                    self.group_indicators_tx.send(group_bars::Event::GlobalDisabled);
-                }
-                self.status_tx
-                    .send(status::Event::GlobalEnabledChanged(self.is_globally_enabled));
-                self.send_space_enabled_status();
-                self.request_space_refresh();
+                self.set_global_enabled(!self.is_globally_enabled);
+            }
+            Event::SetGlobalEnabled(enabled) => {
+                self.set_global_enabled(enabled);
             }
             Event::LoginWindowActive(active) => {
                 if active {
@@ -211,6 +208,20 @@ impl SpaceManager {
                 self.request_space_refresh();
             }
         }
+    }
+
+    fn set_global_enabled(&mut self, enabled: bool) {
+        if self.is_globally_enabled == enabled {
+            return;
+        }
+        self.is_globally_enabled = enabled;
+        if !self.is_globally_enabled {
+            self.group_indicators_tx.send(group_bars::Event::GlobalDisabled);
+        }
+        self.status_tx
+            .send(status::Event::GlobalEnabledChanged(self.is_globally_enabled));
+        self.send_space_enabled_status();
+        self.request_space_refresh();
     }
 
     fn handle_space_changed(&mut self, spaces: &[Option<SpaceId>]) {
@@ -498,6 +509,40 @@ mod tests {
         h.send_space_changed(vec![Some(space(10))]);
         let events = drain(&mut h.reactor_rx);
         assert_eq!(*space_changed_spaces(&events).unwrap(), vec![None]);
+    }
+
+    #[test]
+    fn set_global_enabled_pauses_and_resumes() {
+        let mut h = TestHarness::new();
+        h.setup_space(screen(1), space(10));
+        // Enable the space so we can observe pause/resume affecting it.
+        h.on_event(Event::ToggleSpace(screen(1)));
+        h.drain_all();
+
+        // Pause: all spaces become None.
+        h.on_event(Event::SetGlobalEnabled(false));
+        h.drain_all();
+        h.send_space_changed(vec![Some(space(10))]);
+        let events = drain(&mut h.reactor_rx);
+        assert_eq!(*space_changed_spaces(&events).unwrap(), vec![None]);
+
+        // Resume: the enabled space is managed again.
+        h.on_event(Event::SetGlobalEnabled(true));
+        h.drain_all();
+        h.send_space_changed(vec![Some(space(10))]);
+        let events = drain(&mut h.reactor_rx);
+        assert_eq!(*space_changed_spaces(&events).unwrap(), vec![Some(space(10))]);
+    }
+
+    #[test]
+    fn set_global_enabled_is_idempotent() {
+        let mut h = TestHarness::new();
+        h.setup_space(screen(1), space(10));
+
+        // Already enabled; setting enabled again should produce no refresh.
+        h.on_event(Event::SetGlobalEnabled(true));
+        let ws_events = drain_ws(&mut h.ws_rx);
+        assert!(!ws_events.iter().any(|e| matches!(e, window_server::Event::RequestSpaceRefresh)));
     }
 
     #[test]

--- a/src/actor/wm_controller.rs
+++ b/src/actor/wm_controller.rs
@@ -54,6 +54,7 @@ pub enum WmCommand {
 #[serde(rename_all = "snake_case")]
 pub enum WmCmd {
     ToggleGlobalEnabled,
+    SetGlobalEnabled(bool),
     ToggleSpaceActivated,
     Exec(ExecCmd),
 }
@@ -204,6 +205,9 @@ impl WmController {
             }
             Command(Wm(ToggleGlobalEnabled)) => {
                 self.sm_tx.send(space_manager::Event::ToggleGlobalEnabled);
+            }
+            Command(Wm(SetGlobalEnabled(enabled))) => {
+                self.sm_tx.send(space_manager::Event::SetGlobalEnabled(enabled));
             }
             Command(Wm(Exec(cmd))) => {
                 self.exec_cmd(cmd);

--- a/src/bin/glide.rs
+++ b/src/bin/glide.rs
@@ -35,6 +35,10 @@ enum Command {
     Ping(CmdPing),
     #[command()]
     Config(CmdConfig),
+    /// Pause window management on all spaces.
+    Pause,
+    /// Resume window management after pausing.
+    Resume,
 }
 
 /// Manage Glide as a system service.
@@ -120,6 +124,8 @@ fn main() -> Result<(), anyhow::Error> {
                 _ => bail!("Unexpected response"),
             }
         }
+        Command::Pause => set_enabled(make_client()?, false)?,
+        Command::Resume => set_enabled(make_client()?, true)?,
         Command::Config(CmdConfig {
             config,
             action: ConfigSubcommand::Update(CmdUpdate { watch }),
@@ -180,6 +186,17 @@ fn main() -> Result<(), anyhow::Error> {
     }
 
     Ok(())
+}
+
+fn set_enabled(client: Client, enabled: bool) -> Result<(), anyhow::Error> {
+    match client.send(Request::SetEnabled(enabled))? {
+        Response::Success => {
+            println!("Glide {}", if enabled { "resumed" } else { "paused" });
+            Ok(())
+        }
+        Response::Error(e) => bail!("{e}"),
+        _ => bail!("Unexpected response"),
+    }
 }
 
 fn launch(config: Option<PathBuf>, restore: bool) -> Result<(), anyhow::Error> {


### PR DESCRIPTION
I opted to add a new event `SetGlobalEnabled(boolean)` that idempotently updates the enabled state. Under the hood the implementation of the existing toggle event handler uses the same code. An alternative would be to keep just the toggle event and expose the enabled state from the server.

Even though this adds two ways to do the same thing in the event interface I think it's the right call because it rules out the possibility of any race conditions that may arise by reading the state and acting upon it (the cli can't track the enabled state like is done in the status bar). Happy to change this approach!