### PR TITLE
fix: Keep floating windows on top when selected via Mission Control

### DIFF
--- a/src/actor/layout.rs
+++ b/src/actor/layout.rs
@@ -1367,6 +1367,12 @@ impl LayoutManager {
         self.try_layout(space).unwrap()
     }
 
+    /// Whether the layout tracks this window as floating (i.e. excluded from
+    /// the tiling order and kept above the tiled windows).
+    pub fn is_floating_window(&self, wid: WindowId) -> bool {
+        self.floating_windows.contains(&wid)
+    }
+
     fn top_layer_windows(&self, space: SpaceId) -> Vec<WindowId> {
         let Some(layout) = self.try_layout(space) else {
             return Vec::new();

--- a/src/actor/reactor.rs
+++ b/src/actor/reactor.rs
@@ -1042,7 +1042,39 @@ impl Reactor {
         if current_top_wsids == desired_visible_wsids {
             response.focus_window.take();
             response.raise_windows.clear();
+            return response;
         }
+
+        // If the frontmost on-screen window is one of our own floating windows
+        // rather than a tiled window we're about to raise, the user has a
+        // floating window on top — typically one they just selected from
+        // Mission Control. Raising the tiled windows would bury it (and yank
+        // focus away), so skip the reorder for this space change and leave the
+        // current stacking untouched. (Raising the tiled windows and then
+        // re-raising the floating one on top causes a jarring flicker, and the
+        // tiled order is corrected anyway the next time a tiled window is
+        // focused or the space is shown without a floating window on top.)
+        //
+        // We only skip for windows the layout tracks as floating; a foreign
+        // window on top (e.g. another app's panel) should still let the managed
+        // windows surface.
+        //
+        // We rely on the window-server order from the space-change snapshot
+        // rather than the layout's focused window because the focus-change
+        // event may not have been processed by the time the space change
+        // arrives.
+        if response.focus_window.is_none()
+            && let Some(front_wsid) = visible_window_order
+                .iter()
+                .copied()
+                .find(|wsid| self.should_compare_visible_window(*wsid))
+            && !desired_visible_wsids.contains(&front_wsid)
+            && let Some(&front_wid) = self.window_ids.get(&front_wsid)
+            && self.layout.is_floating_window(front_wid)
+        {
+            response.raise_windows.clear();
+        }
+
         response
     }
 
@@ -1572,6 +1604,70 @@ pub mod tests {
 
         assert!(response.raise_windows.is_empty());
         assert!(response.focus_window.is_none());
+    }
+
+    #[test]
+    fn it_keeps_floating_window_on_top_after_space_change() {
+        // Regression test for #195: selecting a floating window from Mission
+        // Control leaves it frontmost and then fires a space change. The
+        // SpaceExposed reorder must not raise the tiled windows over the
+        // floating one (which would bury it and steal focus).
+        let mut apps = Apps::new();
+        let mut reactor = Reactor::new_for_test(LayoutManager::new());
+        let (raise_manager_tx, mut raise_manager_rx) = mpsc::unbounded_channel();
+        reactor.raise_manager_tx = raise_manager_tx;
+        let space = SpaceId::new(1);
+        reactor.handle_event(Event::ScreenParametersChanged {
+            frames: vec![CGRect::new(CGPoint::new(0., 0.), CGSize::new(1000., 1000.))],
+            spaces: vec![Some(space)],
+            scale_factors: vec![2.0],
+            converter: CoordinateConverter::default(),
+        });
+        reactor.handle_events(apps.make_app_with_opts(
+            1,
+            make_windows(2),
+            Some(WindowId::new(1, 1)),
+            true,
+        ));
+        reactor.handle_event(Event::StartupComplete);
+        reactor.handle_event(Event::ApplicationGloballyActivated(1));
+        apps.simulate_until_quiet(&mut reactor);
+
+        // Float the focused window (1, 1), leaving (1, 2) tiled.
+        let floating = WindowId::new(1, 1);
+        reactor.handle_event(Event::Command(Command::Layout(
+            LayoutCommand::ToggleWindowFloating,
+        )));
+        apps.simulate_until_quiet(&mut reactor);
+        while raise_manager_rx.try_recv().is_ok() {}
+        assert!(reactor.layout.is_floating_window(floating));
+
+        // The space change reports the floating window frontmost, above the
+        // tiled windows it would otherwise reorder.
+        let desired = reactor
+            .layout
+            .handle_event(LayoutEvent::SpaceExposed(space, CGSize::new(1000., 1000.)))
+            .raise_windows;
+        assert!(!desired.contains(&floating));
+        let mut on_screen = vec![WindowServerInfo {
+            id: reactor.windows[&floating].window_server_id.unwrap(),
+            pid: floating.pid,
+            layer: 0,
+            frame: reactor.windows[&floating].frame_monotonic,
+        }];
+        on_screen.extend(desired.iter().map(|wid| WindowServerInfo {
+            id: reactor.windows[wid].window_server_id.unwrap(),
+            pid: wid.pid,
+            layer: 0,
+            frame: reactor.windows[wid].frame_monotonic,
+        }));
+        reactor.handle_event(Event::SpaceChanged(
+            vec![Some(space)],
+            WindowsOnScreen::new(on_screen),
+        ));
+
+        // No raise: the floating window is left on top, undisturbed.
+        assert!(raise_manager_rx.try_recv().is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Selecting a floating window from Mission Control briefly raised it, then sent it back behind the tiled windows with focus returning to the previously focused window. Fixes #195.

Selecting the same window via the Dock or cmd-tab worked fine — the difference is that Mission Control transitions through its own space, so returning fires a space-change event while Dock/cmd-tab do not.

## Cause

Returning from Mission Control fires a space change, whose `SpaceExposed` response raises the tiled windows to restore their layout order (added in "Surface reordered top-layer windows on space change", 3b8cb41 — confirmed via bisect). When the user has just selected a floating window it is frontmost but not part of the tiling order, so raising the tiled windows buried it and yanked focus away.

## Fix

In `filter_response`, when the frontmost on-screen window is one of glide's **own floating windows** (via the new `LayoutManager::is_floating_window`), skip the reorder for that space change and leave the stacking untouched. The other cases are unchanged:

- a true no-op stays a no-op;
- a genuine tiled reorder still happens;
- a **foreign** window on top (e.g. another app's panel) still lets the managed windows surface.

We key off the window-server order snapshot from the space-change event rather than the layout's focused window, because the focus-change event may not have been processed by the time the space change arrives.

### Why skip rather than re-raise

A first attempt raised the tiled windows and then re-raised the floating one on top. Since macOS raises always go to the absolute front, the floating window got covered for a frame or two — a jarring flicker. Skipping the reorder avoids it entirely; the tiled order is corrected anyway the next time a tiled window is focused or the space is shown without a floating window on top.

## Testing

- Added `it_keeps_floating_window_on_top_after_space_change`, which floats a window and drives a real `SpaceChanged` to assert the tiled windows aren't raised over it.
- Full `cargo test` passes (including `it_surfaces_top_layer_windows_when_top_managed_set_differs`, which guards the foreign-window case).
- Manually verified against the repro: floating window stays on top with focus and no flicker; normal space switches onto tiled windows still reorder as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
