### PR TITLE
improve: Rename app_rules config section to window_rules

### DIFF
--- a/glide.default.toml
+++ b/glide.default.toml
@@ -242,15 +242,15 @@ scroll.single_column_aspect_ratio = ""
 #   float           - true to float matching windows, false to tile them
 #
 # Example:
-#   [[app_rules]]
+#   [[window_rules]]
 #   if.app_id = "com.example.X"
 #   if.title_regex = "Dialog"
 #   float = true
 #
-#   [[app_rules]]
+#   [[window_rules]]
 #   if.app_id = "com.example.X"
 #   float = false
 #
-#   [[app_rules]]
+#   [[window_rules]]
 #   if.title_substring = "Preferences"
 #   float = true

--- a/src/actor/layout.rs
+++ b/src/actor/layout.rs
@@ -15,7 +15,7 @@ use tracing::{debug, error, warn};
 
 use crate::actor::app::{WindowId, pid_t};
 use crate::collections::{BTreeExt, BTreeSet, HashMap, HashSet};
-use crate::config::{AppRule, AppRuleConditions, Config, NewWindowPlacement, ScrollConfig};
+use crate::config::{Config, NewWindowPlacement, ScrollConfig, WindowRule, WindowRuleConditions};
 use crate::model::scroll_viewport::ViewportState;
 use crate::model::{
     ContainerKind, Direction, LayoutId, LayoutKind, LayoutTree, NodeId, Orientation,
@@ -228,7 +228,7 @@ pub struct LayoutManager {
     #[serde(skip)]
     scroll_enabled: bool,
     #[serde(skip)]
-    app_rules: Vec<AppRule>,
+    window_rules: Vec<WindowRule>,
     #[serde(skip)]
     interactive_resize: Option<InteractiveScrollResize>,
     #[serde(skip)]
@@ -244,7 +244,7 @@ enum WindowClass {
 
 /// Returns true if every specified condition of `rule` matches the window. A
 /// rule with no conditions matches every window.
-fn app_rule_matches(conditions: &AppRuleConditions, info: &LayoutWindowInfo) -> bool {
+fn window_rule_matches(conditions: &WindowRuleConditions, info: &LayoutWindowInfo) -> bool {
     let title = info.title.as_ref().map(|t| t.expose_secret().as_str());
     let eq = |pattern: Option<&str>, value: Option<&str>| {
         pattern.map_or(true, |p| value.is_some_and(|v| v.eq_ignore_ascii_case(p)))
@@ -265,7 +265,7 @@ fn app_rule_matches(conditions: &AppRuleConditions, info: &LayoutWindowInfo) -> 
         && eq(conditions.ax_subrole.as_deref(), info.ax_subrole.as_deref())
 }
 
-fn classify_window(rules: &[AppRule], info: &LayoutWindowInfo) -> WindowClass {
+fn classify_window(rules: &[WindowRule], info: &LayoutWindowInfo) -> WindowClass {
     use LayoutWindowInfo as Info;
 
     // Phantom/non-window cases are handled first and can't be overridden by app
@@ -303,7 +303,7 @@ fn classify_window(rules: &[AppRule], info: &LayoutWindowInfo) -> WindowClass {
     }
 
     // The first matching user rule overrides the built-in heuristics below.
-    if let Some(rule) = rules.iter().find(|rule| app_rule_matches(&rule.conditions, info)) {
+    if let Some(rule) = rules.iter().find(|rule| window_rule_matches(&rule.conditions, info)) {
         return if rule.float {
             WindowClass::FloatByDefault
         } else {
@@ -337,7 +337,7 @@ impl LayoutManager {
             default_layout_kind: LayoutKind::default(),
             scroll_cfg: Config::default().settings.experimental.scroll.validated(),
             scroll_enabled: false,
-            app_rules: Vec::new(),
+            window_rules: Vec::new(),
             interactive_resize: None,
             interactive_move: None,
         }
@@ -347,7 +347,7 @@ impl LayoutManager {
         // TODO: store a reference to Config instead of cloning fields
         self.scroll_cfg = config.settings.experimental.scroll.clone().validated();
         self.scroll_enabled = self.scroll_cfg.enable;
-        self.app_rules = config.app_rules.clone();
+        self.window_rules = config.window_rules.clone();
         self.default_layout_kind = match (self.scroll_enabled, config.settings.default_layout_kind)
         {
             (false, LayoutKind::Scroll) => {
@@ -534,7 +534,7 @@ impl LayoutManager {
                         if self.tree.window_node(layout, *wid).is_some() {
                             return true;
                         }
-                        match classify_window(&self.app_rules, window_map.get(wid).unwrap()) {
+                        match classify_window(&self.window_rules, window_map.get(wid).unwrap()) {
                             WindowClass::Untracked => false,
                             WindowClass::FloatByDefault => {
                                 add_floating.push(*wid);
@@ -568,7 +568,7 @@ impl LayoutManager {
             }
             LayoutEvent::WindowAdded(space, wid, info) => {
                 self.debug_tree(space);
-                match classify_window(&self.app_rules, &info) {
+                match classify_window(&self.window_rules, &info) {
                     WindowClass::FloatByDefault => self.add_floating_window(wid, Some(space)),
                     WindowClass::Regular => {
                         let layout = self.layout(space);
@@ -1585,7 +1585,7 @@ mod tests {
     use test_log::test;
 
     use super::*;
-    use crate::config::AppRuleConditions;
+    use crate::config::WindowRuleConditions;
 
     fn rect(x: i32, y: i32, w: i32, h: i32) -> CGRect {
         CGRect::new(CGPoint::new(x as f64, y as f64), CGSize::new(w as f64, h as f64))
@@ -1625,8 +1625,8 @@ mod tests {
 
     #[test]
     fn app_id_rule_floats_matching_window_only() {
-        let rules = [AppRule {
-            conditions: AppRuleConditions {
+        let rules = [WindowRule {
+            conditions: WindowRuleConditions {
                 app_id: Some("com.example.X".into()),
                 ..Default::default()
             },
@@ -1644,16 +1644,16 @@ mod tests {
     #[test]
     fn earlier_rule_wins() {
         let rules = [
-            AppRule {
-                conditions: AppRuleConditions {
+            WindowRule {
+                conditions: WindowRuleConditions {
                     app_id: Some("com.example.X".into()),
                     title_regex: Some("Dialog".parse().unwrap()),
                     ..Default::default()
                 },
                 float: true,
             },
-            AppRule {
-                conditions: AppRuleConditions {
+            WindowRule {
+                conditions: WindowRuleConditions {
                     app_id: Some("com.example.X".into()),
                     ..Default::default()
                 },
@@ -1672,8 +1672,8 @@ mod tests {
 
     #[test]
     fn rule_conditions_combine_with_and() {
-        let rules = [AppRule {
-            conditions: AppRuleConditions {
+        let rules = [WindowRule {
+            conditions: WindowRuleConditions {
                 app_name: Some("Code".into()),
                 title_substring: Some("Settings".into()),
                 ax_role: Some("AXWindow".into()),
@@ -1697,8 +1697,8 @@ mod tests {
 
     #[test]
     fn rule_conditions_match_case_insensitively() {
-        let rules = [AppRule {
-            conditions: AppRuleConditions {
+        let rules = [WindowRule {
+            conditions: WindowRuleConditions {
                 app_id: Some("COM.EXAMPLE.x".into()),
                 app_name: Some("code".into()),
                 title_regex: Some("dialog".parse().unwrap()),
@@ -1722,8 +1722,8 @@ mod tests {
     fn condition_does_not_match_when_attribute_is_absent() {
         // A rule that requires an attribute must not match a window that lacks
         // it; the condition should fail rather than be skipped.
-        let rules = [AppRule {
-            conditions: AppRuleConditions {
+        let rules = [WindowRule {
+            conditions: WindowRuleConditions {
                 app_id: Some("com.example.X".into()),
                 ..Default::default()
             },
@@ -1737,8 +1737,8 @@ mod tests {
     #[test]
     fn rule_overrides_builtin_float_heuristics() {
         // System Preferences floats by default; a rule can force it to tile.
-        let rules = [AppRule {
-            conditions: AppRuleConditions {
+        let rules = [WindowRule {
+            conditions: WindowRuleConditions {
                 app_id: Some("com.apple.systempreferences".into()),
                 ..Default::default()
             },
@@ -1749,8 +1749,8 @@ mod tests {
         assert_eq!(classify_window(&rules, &info), WindowClass::Regular);
 
         // A non-resizable window floats by default; a rule can force it to tile.
-        let rules = [AppRule {
-            conditions: AppRuleConditions {
+        let rules = [WindowRule {
+            conditions: WindowRuleConditions {
                 app_id: Some("com.example.X".into()),
                 ..Default::default()
             },
@@ -1764,8 +1764,8 @@ mod tests {
 
     #[test]
     fn rules_cannot_override_untracked_phantom_windows() {
-        let rules = [AppRule {
-            conditions: AppRuleConditions::default(),
+        let rules = [WindowRule {
+            conditions: WindowRuleConditions::default(),
             float: true,
         }];
         let mut info = win_info();

--- a/src/config.rs
+++ b/src/config.rs
@@ -58,7 +58,7 @@ fn default_config_paths() -> Vec<PathBuf> {
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Config {
     pub settings: Settings,
-    pub app_rules: Vec<AppRule>,
+    pub window_rules: Vec<WindowRule>,
     pub keys: Vec<(Hotkey, WmCommand)>,
 }
 
@@ -67,7 +67,7 @@ pub struct Config {
 #[serde(default)]
 struct ConfigPartial {
     settings: SettingsPartial,
-    app_rules: Option<Vec<AppRule>>,
+    window_rules: Option<Vec<WindowRule>>,
     keys: Option<FxHashMap<String, WmCommandOrDisable>>,
 }
 
@@ -151,13 +151,13 @@ impl Serialize for ConfigRegex {
 ///
 /// Conditions are nested under `if`; all specified conditions must match
 /// (logical AND) for the rule to apply. Rules are evaluated in order and the
-/// first matching rule wins. See `app_rules` in the configuration.
+/// first matching rule wins. See `window_rules` in the configuration.
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 #[serde(deny_unknown_fields)]
-pub struct AppRule {
+pub struct WindowRule {
     /// Conditions a window must satisfy for this rule to apply.
     #[serde(rename = "if", default)]
-    pub conditions: AppRuleConditions,
+    pub conditions: WindowRuleConditions,
     /// Whether matching windows should float (`true`) or tile (`false`).
     pub float: bool,
 }
@@ -169,7 +169,7 @@ pub struct AppRule {
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Default)]
 #[serde(deny_unknown_fields)]
 #[serde(default)]
-pub struct AppRuleConditions {
+pub struct WindowRuleConditions {
     /// Application bundle identifier, matched exactly (e.g. "com.apple.Safari").
     pub app_id: Option<String>,
     /// Substring match on the application's localized name.
@@ -355,7 +355,7 @@ impl ConfigPartial {
         }
         Ok(Config {
             settings: self.settings.validate()?,
-            app_rules: self.app_rules.unwrap_or_default(),
+            window_rules: self.window_rules.unwrap_or_default(),
             keys,
         })
     }
@@ -370,7 +370,7 @@ impl ConfigPartial {
         keys.extend(high.keys.unwrap_or_default());
         Self {
             settings: SettingsPartial::merge(low.settings, high.settings),
-            app_rules: high.app_rules.or(low.app_rules),
+            window_rules: high.window_rules.or(low.window_rules),
             keys: Some(keys),
         }
     }
@@ -479,15 +479,15 @@ mod tests {
     }
 
     #[test]
-    fn app_rules_are_empty_by_default() {
-        assert!(Config::default().app_rules.is_empty());
+    fn window_rules_are_empty_by_default() {
+        assert!(Config::default().window_rules.is_empty());
     }
 
     #[test]
-    fn app_rules_parse() {
+    fn window_rules_parse() {
         let config = Config::parse(
             r#"
-            app_rules = [
+            window_rules = [
               { if = { app_id = "com.example.X", title_regex = "Dialog" }, float = true },
               { if = { title_substring = "Preferences", ax_subrole = "AXDialog" }, float = true },
             ]
@@ -495,18 +495,18 @@ mod tests {
         )
         .unwrap();
         assert_eq!(
-            config.app_rules,
+            config.window_rules,
             vec![
-                AppRule {
-                    conditions: AppRuleConditions {
+                WindowRule {
+                    conditions: WindowRuleConditions {
                         app_id: Some("com.example.X".into()),
                         title_regex: Some("Dialog".parse().unwrap()),
                         ..Default::default()
                     },
                     float: true,
                 },
-                AppRule {
-                    conditions: AppRuleConditions {
+                WindowRule {
+                    conditions: WindowRuleConditions {
                         title_substring: Some("Preferences".into()),
                         ax_subrole: Some("AXDialog".into()),
                         ..Default::default()
@@ -518,20 +518,20 @@ mod tests {
     }
 
     #[test]
-    fn app_rules_parse_with_dotted_if_keys() {
+    fn window_rules_parse_with_dotted_if_keys() {
         // The `if.app_id` dotted-key form from the aerospace-style API.
         let config = Config::parse(
             r#"
-            [[app_rules]]
+            [[window_rules]]
             if.app_id = "com.example.X"
             float = true
             "#,
         )
         .unwrap();
         assert_eq!(
-            config.app_rules,
-            vec![AppRule {
-                conditions: AppRuleConditions {
+            config.window_rules,
+            vec![WindowRule {
+                conditions: WindowRuleConditions {
                     app_id: Some("com.example.X".into()),
                     ..Default::default()
                 },
@@ -541,10 +541,10 @@ mod tests {
     }
 
     #[test]
-    fn app_rule_invalid_regex_is_rejected() {
+    fn window_rule_invalid_regex_is_rejected() {
         let err = Config::parse(
             r#"
-            app_rules = [{ if = { title_regex = "(unterminated" }, float = true }]
+            window_rules = [{ if = { title_regex = "(unterminated" }, float = true }]
             "#,
         )
         .unwrap_err();


### PR DESCRIPTION
The rules added in #200 match and act on individual windows, not apps: most conditions (title_regex, title_substring, ax_role, ax_subrole) are window-level, the float action applies per window, and even an app_id-only rule fires once per window. "window_rules" describes what is matched and acted upon, and matches the term used by other tiling window managers (KWin "Window Rules", Hyprland windowrule, yabai rule).

cc @tom-sherman 