### PR TITLE
ci: Run tests for merge queue groups

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,8 @@
 name: Tests
 
 on:
+  merge_group:
+    types: [checks_requested]
   push:
     branches: ["main"]
   pull_request:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,7 @@ env:
 
 jobs:
   check:
+    name: Rust check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -26,6 +27,7 @@ jobs:
         run: cargo check --verbose --locked --target aarch64-apple-darwin
 
   build:
+    name: Rust build and test
     runs-on: macos-15
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

- trigger the Tests workflow for GitHub merge groups
- allow the existing `check` and `build` jobs to validate queued changes

## Why

GitHub merge queues create temporary merge-group commits. Required Actions checks must run on the `merge_group` event or queued pull requests time out without reporting CI.

## Validation

- `git diff --check`
- YAML parsed successfully
