### PR TITLE
move to accessibility objc2 branch and partially migrate off core-foundation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,23 +4,24 @@ version = 4
 
 [[package]]
 name = "accessibility"
-version = "0.3.0"
-source = "git+https://github.com/eiz/accessibility?branch=master#173e898d4a52ee0afe0224ecb458d324057856e7"
+version = "0.4.0"
+source = "git+https://github.com/tmandry/accessibility?branch=objc2-migration#1e827c4fe002aa55c8f7c31e244a514e432f4e1c"
 dependencies = [
  "accessibility-sys",
- "cocoa",
- "core-foundation",
- "core-graphics-types",
- "objc",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-foundation",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "accessibility-sys"
-version = "0.2.0"
-source = "git+https://github.com/eiz/accessibility?branch=master#173e898d4a52ee0afe0224ecb458d324057856e7"
+version = "0.3.0"
+source = "git+https://github.com/tmandry/accessibility?branch=objc2-migration#1e827c4fe002aa55c8f7c31e244a514e432f4e1c"
 dependencies = [
- "core-foundation-sys",
+ "libc",
+ "objc2-application-services",
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -165,12 +166,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "block"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
-
-[[package]]
 name = "block2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -281,35 +276,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
-name = "cocoa"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad36507aeb7e16159dfe68db81ccc27571c3ccd4b76fb2fb72fc59e7a4b1b64c"
-dependencies = [
- "bitflags 2.11.0",
- "block",
- "cocoa-foundation",
- "core-foundation",
- "core-graphics 0.24.0",
- "foreign-types",
- "libc",
- "objc",
-]
-
-[[package]]
-name = "cocoa-foundation"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81411967c50ee9a1fc11365f8c585f863a22a9697c89239c452292c40ba79b0d"
-dependencies = [
- "bitflags 2.11.0",
- "block",
- "core-foundation",
- "core-graphics-types",
- "objc",
-]
-
-[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -330,19 +296,6 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
-
-[[package]]
-name = "core-graphics"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa95a34622365fa5bbf40b20b75dba8dfa8c94c734aea8ac9a5ca38af14316f1"
-dependencies = [
- "bitflags 2.11.0",
- "core-foundation",
- "core-graphics-types",
- "foreign-types",
- "libc",
-]
 
 [[package]]
 name = "core-graphics"
@@ -699,7 +652,7 @@ dependencies = [
  "bitflags 2.11.0",
  "clap",
  "core-foundation",
- "core-graphics 0.25.0",
+ "core-graphics",
  "core-graphics-types",
  "dirs",
  "indexmap 2.13.0",
@@ -1008,15 +961,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "670fdfda89751bc4a84ac13eaa63e205cf0fd22b4c9a5fbfa085b63c1f1d3a30"
 
 [[package]]
-name = "malloc_buf"
-version = "0.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1176,15 +1120,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "objc"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
-dependencies = [
- "malloc_buf",
-]
-
-[[package]]
 name = "objc2"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1200,11 +1135,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
  "bitflags 2.11.0",
+ "libc",
  "objc2",
  "objc2-core-foundation",
  "objc2-core-graphics",
  "objc2-foundation",
  "objc2-quartz-core",
+]
+
+[[package]]
+name = "objc2-application-services"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69282c2b5bc58fba07cb9de2113619532eb551e98efe3d8d695509ef45fbd53b"
+dependencies = [
+ "bitflags 2.11.0",
+ "libc",
+ "objc2-core-foundation",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,8 +106,10 @@ objc2-core-foundation = { version = "0.3.2", default-features = false, features 
 ] }
 objc2-core-graphics = { version = "0.3.2", default-features = false, features = [
     "CGDirectDisplay",
-    "CGRemoteOperation",
     "CGError",
+    "CGGeometry",
+    "CGRemoteOperation",
+    "CGWindow",
 ] }
 objc2-foundation = { version = "0.3.2", default-features = false, features = [
     "NSArray",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,8 +43,8 @@ release.codegen-units = 1
 exec_cmd = []
 
 [dependencies]
-accessibility = { version = "0.3.0", git = "https://github.com/eiz/accessibility", branch = "master" }
-accessibility-sys = { version = "0.2.0", git = "https://github.com/eiz/accessibility", branch = "master" }
+accessibility = { version = "0.4.0", git = "https://github.com/tmandry/accessibility", branch = "objc2-migration" }
+accessibility-sys = { version = "0.3.0", git = "https://github.com/tmandry/accessibility", branch = "objc2-migration" }
 anyhow = "1.0.83"
 ascii_tree = "0.1.1"
 bitflags = "2.4.1"
@@ -94,8 +94,11 @@ objc2-quartz-core = { version = "0.3.2", default-features = false, features = [
 ] }
 objc2-core-foundation = { version = "0.3.2", default-features = false, features = [
     "alloc",
+    "CFArray",
     "CFCGTypes",
+    "CFDictionary",
     "CFMessagePort",
+    "CFNumber",
     "CFRunLoop",
     "CFData",
     "CFDate",

--- a/examples/devtool.rs
+++ b/examples/devtool.rs
@@ -6,15 +6,15 @@
 use std::env::VarError;
 use std::future::Future;
 use std::path::PathBuf;
-use std::ptr;
+use std::ptr::{self, NonNull};
 use std::time::Instant;
 
 use accessibility::{AXUIElement, AXUIElementAttributes};
-use accessibility_sys::{AXUIElementCopyElementAtPosition, AXUIElementRef, pid_t};
+use accessibility_sys::pid_t;
 use anyhow::{Context, bail};
 use clap::{Parser, Subcommand};
 use core_foundation::array::CFArray;
-use core_foundation::base::{FromMutVoid, TCFType};
+use core_foundation::base::TCFType;
 use core_foundation::dictionary::CFDictionaryRef;
 use core_graphics::display::{CGDisplayBounds, CGMainDisplayID};
 use core_graphics::window::{
@@ -29,6 +29,7 @@ use glide_wm::sys::window_server::{self, WindowServerId, get_window};
 use glide_wm::sys::{self};
 use livesplit_hotkey::{ConsumePreference, Modifiers};
 use objc2_app_kit::{NSRunningApplication, NSScreen, NSWindow, NSWindowNumberListOptions};
+use objc2_core_foundation::CFRetained;
 use objc2_foundation::{MainThreadMarker, NSString};
 use tokio::sync::mpsc::{self, UnboundedReceiver, unbounded_channel};
 use tracing::info;
@@ -193,10 +194,11 @@ async fn main() -> anyhow::Result<()> {
         }
         Command::App(App::ReadMainWindow { pid, wait }) => {
             let app = AXUIElement::application(pid);
-            println!("frontmost = {:?}", app.frontmost()?);
+            println!("frontmost = {:?}", &*app.frontmost()?);
             let main_window = if opt.verbose {
-                let main_window = dbg!(app.main_window()?);
-                let main_window_id: WindowServerId = (&app.main_window()?).try_into()?;
+                let main_window = app.main_window()?;
+                dbg!(&*main_window);
+                let main_window_id: WindowServerId = (&*app.main_window()?).try_into()?;
                 dbg!(main_window_id);
                 main_window
             } else {
@@ -211,7 +213,7 @@ async fn main() -> anyhow::Result<()> {
                 std::io::stdin().read_line(&mut String::new())?;
                 app.set_messaging_timeout(3600.0)?;
             }
-            dbg!(main_window.main()?);
+            dbg!(&*main_window.main()?);
         }
         Command::App(App::Run { pid_or_bundle }) => {
             run_app_actor(pid_or_bundle).await?;
@@ -330,20 +332,24 @@ async fn inspect_inner(mut rx: UnboundedReceiver<()>, mtm: MainThreadMarker) {
         let Some(pos) = get_mouse_pos(converter) else { continue };
         // This API doesn't always work, but for some reason get_window_at_point
         // *never* works from devtool.
-        let mut element: AXUIElementRef = ptr::null_mut();
+        let mut element: *const accessibility_sys::AXUIElement = ptr::null();
         let err = unsafe {
-            AXUIElementCopyElementAtPosition(
-                AXUIElement::system_wide().as_CFTypeRef() as _,
+            AXUIElement::system_wide().as_sys().copy_element_at_position(
                 pos.x as f32,
                 pos.y as f32,
-                &raw mut element,
+                NonNull::new_unchecked(&mut element),
             )
         };
-        if err != 0 {
-            println!("Failed to get element under cursor: {err:?}");
+        if let Some(err) = accessibility::AXError::from_raw(err) {
+            println!("Failed to get element under cursor: {err}");
             continue;
         }
-        let elem = unsafe { AXUIElement::from_mut_void(element as *mut _) };
+        // SAFETY: `element` is non-null on success, and owned per the copy rule.
+        let elem = unsafe {
+            CFRetained::cast_unchecked::<AXUIElement>(CFRetained::from_raw(NonNull::new_unchecked(
+                element.cast_mut(),
+            )))
+        };
         let ax_window = match elem.window() {
             Ok(win) => win,
             Err(e) => {
@@ -355,7 +361,7 @@ async fn inspect_inner(mut rx: UnboundedReceiver<()>, mtm: MainThreadMarker) {
         };
         println!("{:#?}", ax_window.privacy_sensitive_inspect());
         let Some(info) =
-            WindowServerId::try_from(&ax_window).ok().and_then(|wsid| get_window(wsid))
+            WindowServerId::try_from(&*ax_window).ok().and_then(|wsid| get_window(wsid))
         else {
             println!("Couldn't get window server info for {element:?}");
             continue;
@@ -441,7 +447,7 @@ async fn get_windows_with_ax(opt: &Opt, serial: bool, print: bool) {
 }
 
 fn get_windows_for_app(
-    app: AXUIElement,
+    app: CFRetained<AXUIElement>,
     verbose: bool,
 ) -> Result<Vec<(WindowInfo, String)>, accessibility::Error> {
     let Ok(windows) = &app.windows() else {
@@ -461,7 +467,7 @@ fn get_windows_for_app(
 fn get_apps(opt: &Opt) {
     for (pid, _bundle_id) in sys::app::running_apps(opt.bundle.clone()) {
         let app = AXUIElement::application(pid);
-        println!("{app:#?}");
+        println!("{:#?}", &*app);
     }
 }
 

--- a/examples/devtool.rs
+++ b/examples/devtool.rs
@@ -13,13 +13,6 @@ use accessibility::{AXUIElement, AXUIElementAttributes};
 use accessibility_sys::pid_t;
 use anyhow::{Context, bail};
 use clap::{Parser, Subcommand};
-use core_foundation::array::CFArray;
-use core_foundation::base::TCFType;
-use core_foundation::dictionary::CFDictionaryRef;
-use core_graphics::display::{CGDisplayBounds, CGMainDisplayID};
-use core_graphics::window::{
-    CGWindowID, CGWindowListCopyWindowInfo, kCGNullWindowID, kCGWindowListOptionOnScreenOnly,
-};
 use glide_wm::actor::{self, reactor};
 use glide_wm::sys::app::{AXUIElementExt, AppInfo, NSRunningApplicationExt, WindowInfo};
 use glide_wm::sys::event::{self, get_mouse_pos};
@@ -30,6 +23,10 @@ use glide_wm::sys::{self};
 use livesplit_hotkey::{ConsumePreference, Modifiers};
 use objc2_app_kit::{NSRunningApplication, NSScreen, NSWindow, NSWindowNumberListOptions};
 use objc2_core_foundation::CFRetained;
+use objc2_core_graphics::{
+    CGDisplayBounds, CGMainDisplayID, CGWindowID, CGWindowListCopyWindowInfo, CGWindowListOption,
+    kCGNullWindowID,
+};
 use objc2_foundation::{MainThreadMarker, NSString};
 use tokio::sync::mpsc::{self, UnboundedReceiver, unbounded_channel};
 use tracing::info;
@@ -376,12 +373,9 @@ async fn inspect_inner(mut rx: UnboundedReceiver<()>, mtm: MainThreadMarker) {
 }
 
 async fn get_windows_with_cg(opt: &Opt, print: bool) {
-    let windows: CFArray<CFDictionaryRef> = unsafe {
-        CFArray::wrap_under_get_rule(CGWindowListCopyWindowInfo(
-            kCGWindowListOptionOnScreenOnly,
-            kCGNullWindowID,
-        ))
-    };
+    let windows =
+        CGWindowListCopyWindowInfo(CGWindowListOption::OptionOnScreenOnly, kCGNullWindowID)
+            .expect("CGWindowListCopyWindowInfo returned NULL");
     if print && opt.verbose {
         println!("{windows:?}");
     }
@@ -395,8 +389,8 @@ async fn get_windows_with_cg(opt: &Opt, print: bool) {
             }
         }
     }
-    let display_id = unsafe { CGMainDisplayID() };
-    let screen = unsafe { CGDisplayBounds(display_id) };
+    let display_id = CGMainDisplayID();
+    let screen = CGDisplayBounds(display_id);
     if print {
         println!("main display = {screen:?}");
     }

--- a/src/actor/app.rs
+++ b/src/actor/app.rs
@@ -20,20 +20,17 @@ use std::sync::LazyLock;
 use std::thread;
 use std::time::{Duration, Instant};
 
-use accessibility::{AXUIElement, AXUIElementActions, AXUIElementAttributes};
+use accessibility::{AXError, AXUIElement, AXUIElementActions, AXUIElementAttributes};
 use accessibility_sys::{
     kAXApplicationActivatedNotification, kAXApplicationDeactivatedNotification,
-    kAXErrorCannotComplete, kAXErrorNoValue, kAXErrorNotificationAlreadyRegistered,
     kAXMainWindowChangedNotification, kAXStandardWindowSubrole, kAXTitleChangedNotification,
     kAXUIElementDestroyedNotification, kAXWindowCreatedNotification,
     kAXWindowDeminiaturizedNotification, kAXWindowMiniaturizedNotification,
     kAXWindowMovedNotification, kAXWindowResizedNotification, kAXWindowRole,
 };
-use core_foundation::runloop::CFRunLoop;
-use core_foundation::string::CFString;
 use objc2::rc::Retained;
 use objc2_app_kit::NSRunningApplication;
-use objc2_core_foundation::CGRect;
+use objc2_core_foundation::{CFRetained, CFRunLoop, CFString, CGRect};
 use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc::{
     UnboundedReceiver as Receiver, UnboundedSender as Sender, WeakUnboundedSender,
@@ -51,7 +48,7 @@ use crate::sys::app::{AXUIElementExt, NSRunningApplicationExt, ProcessInfo};
 pub use crate::sys::app::{AppInfo, WindowInfo, pid_t};
 use crate::sys::event;
 use crate::sys::executor::Executor;
-use crate::sys::geometry::{SameAs, ToCGType, ToICrate};
+use crate::sys::geometry::SameAs;
 use crate::sys::observer::Observer;
 use crate::sys::window_server::WindowServerId;
 
@@ -193,7 +190,7 @@ struct State {
     pid: pid_t,
     bundle_id: Option<String>,
     running_app: Retained<NSRunningApplication>,
-    app: AXUIElement,
+    app: CFRetained<AXUIElement>,
     observer: Observer,
     ws_tx: window_server::Sender,
     requests_tx: WeakUnboundedSender<(Span, Request)>,
@@ -211,7 +208,7 @@ struct State {
 }
 
 struct WindowState {
-    elem: AXUIElement,
+    elem: CFRetained<AXUIElement>,
     is_standard: bool,
     last_seen_txid: TransactionId,
     /// The last frame requested via [`Request::AnimationFrame`] with `set_size`.
@@ -253,7 +250,7 @@ impl State {
         info: AppInfo,
         requests_tx: Sender<(Span, Request)>,
         requests_rx: Receiver<(Span, Request)>,
-        notifications_rx: Receiver<(AXUIElement, String)>,
+        notifications_rx: Receiver<(CFRetained<AXUIElement>, String)>,
         raises_rx: Receiver<(Span, RaiseRequest)>,
         startup: Option<wm_controller::StartupToken>,
     ) {
@@ -272,7 +269,7 @@ impl State {
     async fn handle_incoming(
         this: &RefCell<Self>,
         mut requests_rx: Receiver<(Span, Request)>,
-        mut notifications_rx: Receiver<(AXUIElement, String)>,
+        mut notifications_rx: Receiver<(CFRetained<AXUIElement>, String)>,
     ) {
         loop {
             // Process requests in batches so we can coalesce stale animation
@@ -314,8 +311,7 @@ impl State {
             match this.handle_request(&mut request) {
                 Ok(should_terminate) if should_terminate => return true,
                 Ok(_) => (),
-                #[allow(non_upper_case_globals)]
-                Err(accessibility::Error::Ax(kAXErrorCannotComplete))
+                Err(accessibility::Error::Ax(AXError::CannotComplete))
                     if this.running_app.isTerminated() =>
                 {
                     // The app does not appear to be running anymore.
@@ -353,7 +349,7 @@ impl State {
             set_window_frame_once(&window.elem, frame)?;
         } else {
             trace("set_position", &window.elem, || {
-                window.elem.set_position(frame.origin.to_cgtype())
+                window.elem.set_position(frame.origin)
             })?;
         }
         Ok(())
@@ -415,7 +411,7 @@ impl State {
             windows.push((wid, info));
         }
         self.main_window = self.app.main_window().ok().and_then(|w| self.id(&w).ok());
-        self.is_frontmost = self.app.frontmost().map(|b| b.into()).unwrap_or(false);
+        self.is_frontmost = self.app.frontmost().map(|b| b.value()).unwrap_or(false);
 
         let pid = self.pid;
         if self
@@ -466,8 +462,7 @@ impl State {
             loop {
                 match self.observer.add_notification(&self.app, notif) {
                     Ok(()) => break,
-                    #[allow(non_upper_case_globals)]
-                    Err(accessibility::Error::Ax(kAXErrorNotificationAlreadyRegistered)) => {
+                    Err(accessibility::Error::Ax(AXError::NotificationAlreadyRegistered)) => {
                         debug!(
                             pid = ?self.pid,
                             "Watching app for {notif} was already registered; continuing"
@@ -512,7 +507,7 @@ impl State {
         }
         match request {
             Request::Terminate => {
-                CFRunLoop::get_current().stop();
+                CFRunLoop::current().unwrap().stop();
                 self.send_event(Event::ApplicationThreadTerminated(self.pid));
                 return Ok(true);
             }
@@ -572,7 +567,7 @@ impl State {
                 let frame = trace("frame", &window.elem, || window.elem.frame())?;
                 self.send_event(Event::WindowFrameChanged(
                     wid,
-                    frame.to_icrate(),
+                    frame,
                     txid,
                     Requested(true),
                     None,
@@ -641,7 +636,7 @@ impl State {
                 let frame = trace("frame", &elem, || elem.frame())?;
                 self.send_event(Event::WindowFrameChanged(
                     wid,
-                    frame.to_icrate(),
+                    frame,
                     last_seen_txid,
                     Requested(true),
                     None,
@@ -663,7 +658,7 @@ impl State {
     }
 
     #[instrument(skip_all, fields(app = ?self.app, ?notif))]
-    fn handle_notification(&mut self, elem: AXUIElement, notif: &str) {
+    fn handle_notification(&mut self, elem: CFRetained<AXUIElement>, notif: &str) {
         trace!(?notif, ?elem, "Got notification");
         #[allow(non_upper_case_globals)]
         #[forbid(non_snake_case)]
@@ -708,7 +703,7 @@ impl State {
                 };
                 self.send_event(Event::WindowFrameChanged(
                     wid,
-                    frame.to_icrate(),
+                    frame,
                     last_seen,
                     Requested(false),
                     Some(event::get_mouse_state()),
@@ -775,7 +770,11 @@ impl State {
         let is_standard = {
             let this = this_ref.borrow();
             let window = this.window(first)?;
-            window.elem.subrole().map(|s| s == kAXStandardWindowSubrole).unwrap_or(false)
+            window
+                .elem
+                .subrole()
+                .map(|s| s.to_string() == kAXStandardWindowSubrole)
+                .unwrap_or(false)
         };
         // Check for cancellation again in case the request took too long.
         check_cancel()?;
@@ -807,7 +806,7 @@ impl State {
         // If the app thinks it isn't frontmost but it is, it will get a
         // notification soon and we'll match out against it, incorrectly marking
         // it as quiet. Otherwise nothing bad happens.
-        let is_frontmost: bool = trace("is_frontmost", &this.app, || this.app.frontmost())?.into();
+        let is_frontmost: bool = trace("is_frontmost", &this.app, || this.app.frontmost())?.value();
 
         // Make this the key window. This ensures that the window has focus and
         // can receive keyboard events, and activates the app if it isn't
@@ -821,7 +820,7 @@ impl State {
         // to the application and does not wait for it to complete.
         let make_key_result = crate::sys::window_server::make_key_window(
             this.pid,
-            WindowServerId::try_from(&this.window(first)?.elem)?,
+            WindowServerId::try_from(&*this.window(first)?.elem)?,
         );
         if make_key_result.is_err() {
             warn!(?this.pid, "Failed to activate app");
@@ -960,7 +959,7 @@ impl State {
         // stale events.
         //
         // TODO: I'm not sure this is necessary, for activation events at least.
-        let is_frontmost: bool = trace("is_frontmost", &self.app, || self.app.frontmost())?.into();
+        let is_frontmost: bool = trace("is_frontmost", &self.app, || self.app.frontmost())?.value();
         let old_frontmost = std::mem::replace(&mut self.is_frontmost, is_frontmost);
         debug!(
             "on_activation_changed, pid={:?}, is_frontmost={:?}, old_frontmost={:?}",
@@ -1037,16 +1036,16 @@ impl State {
     }
 
     #[must_use]
-    fn register_window(&mut self, elem: AXUIElement) -> Option<(WindowInfo, WindowId)> {
-        let Ok(info) = WindowInfo::try_from(&elem) else {
+    fn register_window(&mut self, elem: CFRetained<AXUIElement>) -> Option<(WindowInfo, WindowId)> {
+        let Ok(info) = WindowInfo::try_from(&*elem) else {
             return None;
         };
 
-        let wsid = WindowServerId::try_from(&elem)
+        let wsid = WindowServerId::try_from(&*elem)
             .or_else(|e| {
                 if self.bundle_id.as_deref() == Some("com.apple.finder")
                     && let Ok(role) = elem.role()
-                    && role == CFString::from_static_string("AXScrollArea")
+                    && role == CFString::from_static_str("AXScrollArea")
                 {
                     // Finder has a weird window like this; maybe the desktop.
                     Err(e)
@@ -1087,7 +1086,7 @@ impl State {
         fn register_notifs(win: &AXUIElement, state: &State, wsid: Option<WindowServerId>) -> bool {
             // Filter out elements that aren't regular windows.
             match win.role() {
-                Ok(role) if role == kAXWindowRole => (),
+                Ok(role) if role.to_string() == kAXWindowRole => (),
                 _ => return false,
             }
             for notif in WINDOW_NOTIFICATIONS {
@@ -1128,7 +1127,7 @@ impl State {
             if self.windows.contains_key(&wid) {
                 return Ok(wid);
             }
-        } else if let Some((&wid, _)) = self.windows.iter().find(|(_, w)| &w.elem == elem) {
+        } else if let Some((&wid, _)) = self.windows.iter().find(|(_, w)| &*w.elem == elem) {
             return Ok(wid);
         }
         Err(accessibility::Error::NotFound)
@@ -1226,10 +1225,8 @@ const SET_WINDOW_FRAME_RETRIES: usize = 3;
 const SET_WINDOW_FRAME_RETRY_DELAY: Duration = Duration::from_millis(5);
 
 fn set_window_frame_once(window: &AXUIElement, frame: CGRect) -> Result<(), accessibility::Error> {
-    trace("set_size", window, || window.set_size(frame.size.to_cgtype()))?;
-    trace("set_position", window, || {
-        window.set_position(frame.origin.to_cgtype())
-    })?;
+    trace("set_size", window, || window.set_size(frame.size))?;
+    trace("set_position", window, || window.set_position(frame.origin))?;
     Ok(())
 }
 
@@ -1247,7 +1244,7 @@ fn set_window_frame_with_retries(
     let mut observed = requested;
     for attempt in 1..=SET_WINDOW_FRAME_RETRIES {
         set_window_frame_once(window, frame)?;
-        observed = trace("frame", window, || window.frame())?.to_icrate();
+        observed = trace("frame", window, || window.frame())?;
         if observed.same_as(requested) {
             return Ok(());
         }
@@ -1300,10 +1297,9 @@ thread_local! {
     static WARNINGS_SEEN: RefCell<crate::collections::HashSet<(&'static str, String)>> = RefCell::new(Default::default());
 }
 
-/// Converts kAXErrorNoValue to None.
+/// Converts AXError::NoValue to None.
 fn optional<T>(val: Result<T, accessibility::Error>) -> Result<Option<T>, accessibility::Error> {
-    #[expect(non_upper_case_globals)]
-    if let Err(accessibility::Error::Ax(kAXErrorNoValue)) = val {
+    if let Err(accessibility::Error::Ax(AXError::NoValue)) = val {
         return Ok(None);
     }
     val.map(Some)

--- a/src/sys/app.rs
+++ b/src/sys/app.rs
@@ -5,23 +5,18 @@
 
 use std::fmt::{Debug, Formatter};
 
-use accessibility::{AXAttribute, AXUIElement, AXUIElementAttributes};
+use accessibility::{AXAttribute, AXError, AXUIElement, AXUIElementAttributes};
 pub use accessibility_sys::pid_t;
-use accessibility_sys::{
-    kAXErrorAttributeUnsupported, kAXErrorNoValue, kAXStandardWindowSubrole, kAXWindowRole,
-};
-use core_foundation::base::{CFType, TCFType};
-use core_foundation::boolean::CFBoolean;
-use core_foundation::string::CFString;
+use accessibility_sys::{kAXStandardWindowSubrole, kAXWindowRole};
 use objc2::rc::Retained;
 use objc2::{class, msg_send};
 use objc2_app_kit::{NSRunningApplication, NSWorkspace};
-use objc2_core_foundation::CGRect;
+use objc2_core_foundation::{CFBoolean, CFString, CFType, CGRect};
 use objc2_foundation::NSString;
 use redact::Secret;
 use serde::{Deserialize, Serialize};
 
-use super::geometry::{CGRectDef, ToICrate};
+use super::geometry::CGRectDef;
 use super::window_server::WindowServerId;
 
 pub fn running_apps(bundle: Option<String>) -> impl Iterator<Item = (pid_t, AppInfo)> {
@@ -103,19 +98,19 @@ impl TryFrom<&AXUIElement> for WindowInfo {
         let subrole = match element.subrole() {
             Ok(s) => Some(s),
             Err(accessibility::Error::Ax(e))
-                if e == kAXErrorNoValue || e == kAXErrorAttributeUnsupported =>
+                if e == AXError::NoValue || e == AXError::AttributeUnsupported =>
             {
                 None
             }
             Err(e) => return Err(e),
         };
-        let is_standard = role == kAXWindowRole
-            && subrole.as_ref().is_some_and(|s| *s == kAXStandardWindowSubrole);
+        let is_standard = role.to_string() == kAXWindowRole
+            && subrole.as_ref().is_some_and(|s| s.to_string() == kAXStandardWindowSubrole);
         let ax_subrole = subrole.map(|s| s.to_string());
         Ok(WindowInfo {
             is_standard,
             title: element.title().map(|t| t.to_string().into()).unwrap_or_default(),
-            frame: element.frame()?.to_icrate(),
+            frame: element.frame()?,
             sys_id: WindowServerId::try_from(element).ok(),
             is_resizable: element.is_settable(&AXAttribute::size())?,
             ax_role: role.to_string(),
@@ -147,10 +142,10 @@ pub trait AXUIElementExt {
 
 impl AXUIElementExt for AXUIElement {
     fn enhanced_user_interface(&self) -> Result<bool, accessibility::Error> {
-        Ok(self.attribute(&enhanced_ui())?.downcast() == Some(CFBoolean::true_value()))
+        Ok(self.attribute(&enhanced_ui())?.downcast::<CFBoolean>().is_ok_and(|b| b.value()))
     }
     fn set_enhanced_user_interface(&self, enabled: bool) -> Result<(), accessibility::Error> {
-        self.set_attribute(&enhanced_ui(), CFBoolean::from(enabled).as_CFType())
+        self.set_attribute(&enhanced_ui(), CFBoolean::new(enabled))
     }
 
     fn privacy_sensitive_inspect(&self) -> Inspect<'_> {
@@ -159,7 +154,7 @@ impl AXUIElementExt for AXUIElement {
 }
 
 fn enhanced_ui() -> AXAttribute<CFType> {
-    AXAttribute::new(&CFString::from_static_string("AXEnhancedUserInterface"))
+    AXAttribute::new(&CFString::from_static_str("AXEnhancedUserInterface"))
 }
 
 pub struct Inspect<'a>(&'a AXUIElement);
@@ -169,7 +164,7 @@ impl Debug for Inspect<'_> {
         let mut st = f.debug_struct("AXWindow");
         for attr in self.0.attribute_names().unwrap().iter() {
             if let Ok(value) = self.0.attribute(&AXAttribute::new(&attr)) {
-                st.field(&attr.to_string(), &value);
+                st.field(&attr.to_string(), &*value);
             }
         }
         st.finish()

--- a/src/sys/executor.rs
+++ b/src/sys/executor.rs
@@ -11,9 +11,9 @@ use std::rc::{Rc, Weak};
 use std::sync::{Arc, Mutex};
 use std::task::{Context, Poll, Wake};
 
-use core_foundation::runloop::CFRunLoop;
 use objc2::MainThreadMarker;
 use objc2_app_kit::NSApp;
+use objc2_core_foundation::CFRunLoop;
 
 use super::run_loop::WakeupHandle;
 
@@ -26,7 +26,7 @@ pub struct Executor;
 
 impl Executor {
     pub fn run(task: impl Future<Output = ()>) {
-        Self::run_with_loop_fn(task, CFRunLoop::run_current);
+        Self::run_with_loop_fn(task, CFRunLoop::run);
     }
 
     pub fn run_main(mtm: MainThreadMarker, task: impl Future<Output = ()>) {
@@ -100,7 +100,7 @@ impl State {
         let mut context = Context::from_waker(&waker);
         if self.main_task.as_mut().unwrap().as_mut().poll(&mut context) == Poll::Ready(()) {
             self.main_task.take();
-            CFRunLoop::get_current().stop();
+            CFRunLoop::current().unwrap().stop();
         }
     }
 }

--- a/src/sys/geometry.rs
+++ b/src/sys/geometry.rs
@@ -34,34 +34,6 @@ impl ToICrate<ic::CGRect> for cg::CGRect {
     }
 }
 
-pub trait ToCGType<T> {
-    fn to_cgtype(&self) -> T;
-}
-
-impl ToCGType<cg::CGPoint> for ic::CGPoint {
-    fn to_cgtype(&self) -> cg::CGPoint {
-        cg::CGPoint { x: self.x, y: self.y }
-    }
-}
-
-impl ToCGType<cg::CGSize> for ic::CGSize {
-    fn to_cgtype(&self) -> cg::CGSize {
-        cg::CGSize {
-            width: self.width,
-            height: self.height,
-        }
-    }
-}
-
-impl ToCGType<cg::CGRect> for ic::CGRect {
-    fn to_cgtype(&self) -> cg::CGRect {
-        cg::CGRect {
-            origin: self.origin.to_cgtype(),
-            size: self.size.to_cgtype(),
-        }
-    }
-}
-
 pub trait Round {
     fn round(&self) -> Self;
 }

--- a/src/sys/observer.rs
+++ b/src/sys/observer.rs
@@ -1,31 +1,20 @@
 // Copyright The Glide Authors
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use std::borrow::Cow;
 use std::ffi::c_void;
 use std::marker::PhantomData;
 use std::mem::ManuallyDrop;
-use std::ptr;
+use std::ptr::{self, NonNull};
 
-use accessibility::AXUIElement;
-use accessibility_sys::{
-    AXError, AXObserverAddNotification, AXObserverCreate, AXObserverGetRunLoopSource,
-    AXObserverGetTypeID, AXObserverRef, AXObserverRemoveNotification, AXUIElementRef,
-    kAXErrorSuccess, pid_t,
-};
-use core_foundation::base::TCFType;
-use core_foundation::runloop::{CFRunLoopAddSource, CFRunLoopGetCurrent, kCFRunLoopCommonModes};
-use core_foundation::string::{CFString, CFStringRef};
-use core_foundation::{declare_TCFType, impl_TCFType};
-
-declare_TCFType!(AXObserver, AXObserverRef);
-impl_TCFType!(AXObserver, AXObserverRef, AXObserverGetTypeID);
+use accessibility::{AXError, AXUIElement, Error};
+use accessibility_sys::{AXObserver, pid_t};
+use objc2_core_foundation::{CFRetained, CFRunLoop, CFString, kCFRunLoopCommonModes};
 
 /// An observer for accessibility events.
 pub struct Observer {
     callback: *mut (),
     dtor: unsafe fn(*mut ()),
-    observer: ManuallyDrop<AXObserver>,
+    observer: ManuallyDrop<CFRetained<AXObserver>>,
 }
 
 static_assertions::assert_not_impl_any!(Observer: Send);
@@ -51,32 +40,36 @@ static_assertions::assert_not_impl_any!(Observer: Send);
 // fail and can be called before the call to `make_cyclic`. `install` is
 // infallible and can be called inside, meaning the callback passed to it can
 // capture a weak pointer to our object.
-pub struct ObserverBuilder<F>(AXObserver, PhantomData<F>);
+pub struct ObserverBuilder<F>(CFRetained<AXObserver>, PhantomData<F>);
 
 impl Observer {
     /// Creates a new observer for an app, given its `pid`.
     ///
     /// Note that you must call [`ObserverBuilder::install`] on the result of
     /// this function and supply a callback for the observer to have any effect.
-    pub fn new<F: Fn(AXUIElement, &str) + 'static>(
+    pub fn new<F: Fn(CFRetained<AXUIElement>, &str) + 'static>(
         pid: pid_t,
-    ) -> Result<ObserverBuilder<F>, accessibility::Error> {
+    ) -> Result<ObserverBuilder<F>, Error> {
         // SAFETY: We just create an observer here, and check the return code.
         // The callback cannot be called yet. The API guarantees that F will be
         // supplied as the callback in the call to install (and the 'static
         // bound on F means we don't need to worry about variance).
-        let mut observer: AXObserverRef = ptr::null_mut();
-        unsafe {
-            make_result(AXObserverCreate(pid, internal_callback::<F>, &mut observer))?;
-        }
-        Ok(ObserverBuilder(
-            unsafe { AXObserver::wrap_under_create_rule(observer) },
-            PhantomData,
-        ))
+        let mut observer: *mut AXObserver = ptr::null_mut();
+        let err = unsafe {
+            AXObserver::create(
+                pid,
+                Some(internal_callback::<F>),
+                NonNull::new_unchecked(&mut observer),
+            )
+        };
+        make_result(err)?;
+        // SAFETY: AXObserverCreate succeeded, so `observer` is a valid +1 object.
+        let observer = unsafe { CFRetained::from_raw(NonNull::new_unchecked(observer)) };
+        Ok(ObserverBuilder(observer, PhantomData))
     }
 }
 
-impl<F: Fn(AXUIElement, &str) + 'static> ObserverBuilder<F> {
+impl<F: Fn(CFRetained<AXUIElement>, &str) + 'static> ObserverBuilder<F> {
     /// Installs the observer with the supplied callback into the current
     /// thread's run loop.
     pub fn install(self, callback: F) -> Observer {
@@ -84,8 +77,8 @@ impl<F: Fn(AXUIElement, &str) + 'static> ObserverBuilder<F> {
         // internal_callback::<F>. F is 'static, so even if our destructor is
         // not run it will remain valid to call.
         unsafe {
-            let source = AXObserverGetRunLoopSource(self.0.as_concrete_TypeRef());
-            CFRunLoopAddSource(CFRunLoopGetCurrent(), source, kCFRunLoopCommonModes);
+            let source = self.0.run_loop_source();
+            CFRunLoop::current().unwrap().add_source(Some(&source), kCFRunLoopCommonModes);
         }
         Observer {
             callback: Box::into_raw(Box::new(callback)) as *mut (),
@@ -113,12 +106,11 @@ impl Observer {
         &self,
         elem: &AXUIElement,
         notification: &'static str,
-    ) -> Result<(), accessibility::Error> {
+    ) -> Result<(), Error> {
         make_result(unsafe {
-            AXObserverAddNotification(
-                self.observer.as_concrete_TypeRef(),
-                elem.as_concrete_TypeRef(),
-                CFString::from_static_string(notification).as_concrete_TypeRef(),
+            self.observer.add_notification(
+                elem.as_sys(),
+                &CFString::from_static_str(notification),
                 self.callback as *mut c_void,
             )
         })
@@ -128,33 +120,33 @@ impl Observer {
         &self,
         elem: &AXUIElement,
         notification: &'static str,
-    ) -> Result<(), accessibility::Error> {
+    ) -> Result<(), Error> {
         make_result(unsafe {
-            AXObserverRemoveNotification(
-                self.observer.as_concrete_TypeRef(),
-                elem.as_concrete_TypeRef(),
-                CFString::from_static_string(notification).as_concrete_TypeRef(),
-            )
+            self.observer
+                .remove_notification(elem.as_sys(), &CFString::from_static_str(notification))
         })
     }
 }
 
-unsafe extern "C" fn internal_callback<F: Fn(AXUIElement, &str) + 'static>(
-    _observer: AXObserverRef,
-    elem: AXUIElementRef,
-    notif: CFStringRef,
+unsafe extern "C-unwind" fn internal_callback<F: Fn(CFRetained<AXUIElement>, &str) + 'static>(
+    _observer: NonNull<AXObserver>,
+    elem: NonNull<accessibility_sys::AXUIElement>,
+    notif: NonNull<CFString>,
     data: *mut c_void,
 ) {
     let callback = unsafe { &*(data as *const F) };
-    let elem = unsafe { AXUIElement::wrap_under_get_rule(elem) };
-    let notif = unsafe { CFString::wrap_under_get_rule(notif) };
-    let notif = Cow::<str>::from(&notif);
-    callback(elem, &*notif);
+    // SAFETY: `elem` is a valid, unretained (+0) reference for the duration of
+    // this call, and shares layout with `accessibility::AXUIElement`.
+    let elem = unsafe { CFRetained::retain(elem) };
+    let elem = unsafe { CFRetained::cast_unchecked::<AXUIElement>(elem) };
+    // SAFETY: `notif` is a valid reference for the duration of this call.
+    let notif = unsafe { notif.as_ref() };
+    callback(elem, &notif.to_string());
 }
 
-fn make_result(err: AXError) -> Result<(), accessibility::Error> {
-    if err != kAXErrorSuccess {
-        return Err(accessibility::Error::Ax(err));
+fn make_result(err: accessibility_sys::AXError) -> Result<(), Error> {
+    match AXError::from_raw(err) {
+        Some(err) => Err(Error::Ax(err)),
+        None => Ok(()),
     }
-    Ok(())
 }

--- a/src/sys/run_loop.rs
+++ b/src/sys/run_loop.rs
@@ -4,13 +4,10 @@
 //! Helpers for managing run loops.
 
 use std::ffi::c_void;
-use std::{mem, ptr};
+use std::mem;
 
-use core_foundation::base::TCFType;
-use core_foundation::mach_port::CFIndex;
-use core_foundation::runloop::{
-    CFRunLoop, CFRunLoopSource, CFRunLoopSourceContext, CFRunLoopSourceCreate,
-    CFRunLoopSourceSignal, CFRunLoopWakeUp, kCFRunLoopCommonModes,
+use objc2_core_foundation::{
+    CFIndex, CFRetained, CFRunLoop, CFRunLoopSource, CFRunLoopSourceContext, kCFRunLoopCommonModes,
 };
 
 /// A core foundation run loop source.
@@ -21,7 +18,7 @@ use core_foundation::runloop::{
 /// More information is available in the Apple documentation at
 /// https://developer.apple.com/documentation/corefoundation/cfrunloopsource-rhr.
 #[derive(Clone, PartialEq)]
-pub struct WakeupHandle(CFRunLoopSource, CFRunLoop);
+pub struct WakeupHandle(CFRetained<CFRunLoopSource>, CFRetained<CFRunLoop>);
 
 // SAFETY:
 // - CFRunLoopSource and CFRunLoop are ObjC objects which are allowed to be used
@@ -47,20 +44,20 @@ impl WakeupHandle {
     pub fn for_current_thread<F: Fn() + 'static>(order: CFIndex, handler: F) -> WakeupHandle {
         let handler = Box::into_raw(Box::new(Handler { ref_count: 0, func: handler }));
 
-        extern "C-unwind" fn perform<F: Fn() + 'static>(info: *const c_void) {
+        unsafe extern "C-unwind" fn perform<F: Fn() + 'static>(info: *mut c_void) {
             // SAFETY: Only one thread may call these functions, and the mutable
             // reference lives only during the function call. No other code has
             // access to the handler.
             let handler = unsafe { &mut *(info as *mut Handler<F>) };
             (handler.func)();
         }
-        extern "C" fn retain<F>(info: *const c_void) -> *const c_void {
+        unsafe extern "C-unwind" fn retain<F>(info: *const c_void) -> *const c_void {
             // SAFETY: As above.
             let handler = unsafe { &mut *(info as *mut Handler<F>) };
             handler.ref_count += 1;
             info
         }
-        extern "C-unwind" fn release<F>(info: *const c_void) {
+        unsafe extern "C-unwind" fn release<F>(info: *const c_void) {
             // SAFETY: As above.
             let handler = unsafe { &mut *(info as *mut Handler<F>) };
             handler.ref_count -= 1;
@@ -69,40 +66,24 @@ impl WakeupHandle {
             }
         }
 
-        // SAFETY: Strip the C-unwind ABI from the function pointer types since
-        // the core-foundation crate hasn't been updated with this ABI yet. This
-        // should be sound as long as we don't call the transmuted function
-        // pointer from Rust.
-        let release = unsafe {
-            mem::transmute::<extern "C-unwind" fn(*const c_void), extern "C" fn(*const c_void)>(
-                release::<F>,
-            )
-        };
-        let perform = unsafe {
-            mem::transmute::<extern "C-unwind" fn(*const c_void), extern "C" fn(*const c_void)>(
-                perform::<F>,
-            )
-        };
-
         let mut context = CFRunLoopSourceContext {
             version: 0,
             info: handler as *mut c_void,
             retain: Some(retain::<F>),
-            release: Some(release),
+            release: Some(release::<F>),
             copyDescription: None,
             equal: None,
             hash: None,
             schedule: None,
             cancel: None,
-            perform,
+            perform: Some(perform::<F>),
         };
 
-        let source = unsafe {
-            let source = CFRunLoopSourceCreate(ptr::null(), order, &mut context as *mut _);
-            CFRunLoopSource::wrap_under_create_rule(source)
-        };
-        let run_loop = CFRunLoop::get_current();
-        run_loop.add_source(&source, unsafe { kCFRunLoopCommonModes });
+        // SAFETY: `context` is a valid pointer for the duration of this call.
+        let source = unsafe { CFRunLoopSource::new(None, order, &mut context) }
+            .expect("CFRunLoopSourceCreate returned NULL");
+        let run_loop = CFRunLoop::current().expect("no current run loop");
+        run_loop.add_source(Some(&source), unsafe { kCFRunLoopCommonModes });
 
         WakeupHandle(source, run_loop)
     }
@@ -112,10 +93,8 @@ impl WakeupHandle {
     ///
     /// Multiple signals may be collapsed into a single call of the handler.
     pub fn wake(&self) {
-        unsafe {
-            CFRunLoopSourceSignal(self.0.as_concrete_TypeRef());
-            CFRunLoopWakeUp(self.1.as_concrete_TypeRef());
-        }
+        self.0.signal();
+        self.1.wake_up();
     }
 }
 
@@ -126,7 +105,7 @@ mod tests {
     use std::sync::mpsc::{Receiver, Sender, channel};
     use std::thread::JoinHandle;
 
-    use core_foundation::runloop::CFRunLoop;
+    use objc2_core_foundation::CFRunLoop;
 
     use super::WakeupHandle;
 
@@ -152,13 +131,13 @@ mod tests {
                 handler_wakeups.fetch_add(1, Ordering::SeqCst);
                 handler_tx.send(None).unwrap();
                 if handler_shutdown.load(Ordering::SeqCst) {
-                    CFRunLoop::get_current().stop();
+                    CFRunLoop::current().unwrap().stop();
                 }
                 println!("done");
             });
             tx.send(Some(wakeup)).unwrap();
             if run {
-                CFRunLoop::run_current();
+                CFRunLoop::run();
             }
         });
         RunLoopThread {

--- a/src/sys/screen.rs
+++ b/src/sys/screen.rs
@@ -5,15 +5,13 @@ use std::f64;
 use std::ffi::c_int;
 use std::mem::MaybeUninit;
 use std::num::NonZeroU64;
+use std::ptr::NonNull;
 
 use bitflags::bitflags;
-use core_foundation::array::{CFArray, CFArrayRef};
-use core_foundation::base::TCFType;
-use core_foundation::string::{CFString, CFStringRef};
 use objc2::rc::Retained;
 use objc2::{ClassType, msg_send};
 use objc2_app_kit::NSScreen;
-use objc2_core_foundation::{CGPoint, CGRect};
+use objc2_core_foundation::{CFArray, CFRetained, CFString, CGPoint, CGRect};
 use objc2_core_graphics::{CGDisplayBounds, CGError, CGGetActiveDisplayList};
 use objc2_foundation::{MainThreadMarker, NSArray, NSDictionary, NSNumber, ns_string};
 use serde::{Deserialize, Serialize};
@@ -33,7 +31,7 @@ impl SpaceId {
 /// Calculates the screen and space configuration.
 pub struct ScreenCache<S: System = Actual> {
     system: S,
-    uuids: Vec<CFString>,
+    uuids: Vec<CFRetained<CFString>>,
 }
 
 impl ScreenCache<Actual> {
@@ -125,10 +123,7 @@ impl<S: System> ScreenCache<S> {
         self.uuids
             .iter()
             .map(|screen| unsafe {
-                CGSManagedDisplayGetCurrentSpace(
-                    CGSMainConnectionID(),
-                    screen.as_concrete_TypeRef(),
-                )
+                CGSManagedDisplayGetCurrentSpace(CGSMainConnectionID(), screen)
             })
             .map(|id| Some(SpaceId(NonZeroU64::new(id)?)))
             .collect()
@@ -173,7 +168,7 @@ impl CoordinateConverter {
 #[allow(private_interfaces)]
 pub trait System {
     fn cg_screens(&self) -> Result<Vec<CGScreenInfo>, CGError>;
-    fn uuid_for_rect(&self, rect: CGRect) -> CFString;
+    fn uuid_for_rect(&self, rect: CGRect) -> CFRetained<CFString>;
 }
 
 #[derive(Debug, Clone)]
@@ -232,13 +227,11 @@ impl System for Actual {
             .collect())
     }
 
-    fn uuid_for_rect(&self, rect: CGRect) -> CFString {
-        unsafe {
-            CFString::wrap_under_create_rule(CGSCopyBestManagedDisplayForRect(
-                CGSMainConnectionID(),
-                rect,
-            ))
-        }
+    fn uuid_for_rect(&self, rect: CGRect) -> CFRetained<CFString> {
+        // SAFETY: The call returns an owned (+1) CFString, per the copy rule.
+        let uuid = unsafe { CGSCopyBestManagedDisplayForRect(CGSMainConnectionID(), rect) };
+        let uuid = uuid.expect("CGSCopyBestManagedDisplayForRect returned NULL");
+        unsafe { CFRetained::from_raw(uuid) }
     }
 }
 
@@ -323,22 +316,26 @@ pub mod diagnostic {
         SpaceId(NonZeroU64::new(unsafe { CGSGetActiveSpace(CGSMainConnectionID()) }).unwrap())
     }
 
-    pub fn visible_spaces() -> CFArray<SpaceId> {
-        unsafe {
-            let arr = CGSCopySpaces(CGSMainConnectionID(), CGSSpaceMask::ALL_VISIBLE_SPACES);
-            CFArray::wrap_under_create_rule(arr)
-        }
+    pub fn visible_spaces() -> CFRetained<CFArray<SpaceId>> {
+        // SAFETY: the array holds raw (non-retained) space id values, per the
+        // copy rule and the way this private API is documented to behave.
+        let arr = unsafe { CGSCopySpaces(CGSMainConnectionID(), CGSSpaceMask::ALL_VISIBLE_SPACES) };
+        let arr = arr.expect("CGSCopySpaces returned NULL");
+        unsafe { CFRetained::cast_unchecked(CFRetained::from_raw(arr)) }
     }
 
-    pub fn all_spaces() -> CFArray<SpaceId> {
-        unsafe {
-            let arr = CGSCopySpaces(CGSMainConnectionID(), CGSSpaceMask::ALL_SPACES);
-            CFArray::wrap_under_create_rule(arr)
-        }
+    pub fn all_spaces() -> CFRetained<CFArray<SpaceId>> {
+        // SAFETY: as above.
+        let arr = unsafe { CGSCopySpaces(CGSMainConnectionID(), CGSSpaceMask::ALL_SPACES) };
+        let arr = arr.expect("CGSCopySpaces returned NULL");
+        unsafe { CFRetained::cast_unchecked(CFRetained::from_raw(arr)) }
     }
 
-    pub fn managed_displays() -> CFArray {
-        unsafe { CFArray::wrap_under_create_rule(CGSCopyManagedDisplays(CGSMainConnectionID())) }
+    pub fn managed_displays() -> CFRetained<CFArray> {
+        // SAFETY: the call returns an owned (+1) array, per the copy rule.
+        let arr = unsafe { CGSCopyManagedDisplays(CGSMainConnectionID()) };
+        let arr = arr.expect("CGSCopyManagedDisplays returned NULL");
+        unsafe { CFRetained::from_raw(arr) }
     }
 
     pub fn managed_display_spaces() -> Retained<NSArray> {
@@ -353,11 +350,11 @@ pub mod diagnostic {
 unsafe extern "C" {
     fn CGSMainConnectionID() -> c_int;
     fn CGSGetActiveSpace(cid: c_int) -> u64;
-    fn CGSCopySpaces(cid: c_int, mask: CGSSpaceMask) -> CFArrayRef;
-    fn CGSCopyManagedDisplays(cid: c_int) -> CFArrayRef;
+    fn CGSCopySpaces(cid: c_int, mask: CGSSpaceMask) -> Option<NonNull<CFArray>>;
+    fn CGSCopyManagedDisplays(cid: c_int) -> Option<NonNull<CFArray>>;
     fn CGSCopyManagedDisplaySpaces(cid: c_int) -> *mut NSArray;
-    fn CGSManagedDisplayGetCurrentSpace(cid: c_int, uuid: CFStringRef) -> u64;
-    fn CGSCopyBestManagedDisplayForRect(cid: c_int, rect: CGRect) -> CFStringRef;
+    fn CGSManagedDisplayGetCurrentSpace(cid: c_int, uuid: &CFString) -> u64;
+    fn CGSCopyBestManagedDisplayForRect(cid: c_int, rect: CGRect) -> Option<NonNull<CFString>>;
 }
 
 bitflags! {
@@ -388,8 +385,7 @@ bitflags! {
 
 #[cfg(test)]
 mod test {
-    use core_foundation::string::CFString;
-    use objc2_core_foundation::{CGPoint, CGRect, CGSize};
+    use objc2_core_foundation::{CFRetained, CFString, CGPoint, CGRect, CGSize};
 
     use super::{CGError, CGScreenInfo, NSScreenInfo, ScreenCache, ScreenId, System};
 
@@ -400,8 +396,8 @@ mod test {
         fn cg_screens(&self) -> Result<Vec<CGScreenInfo>, CGError> {
             Ok(self.cg_screens.clone())
         }
-        fn uuid_for_rect(&self, _rect: CGRect) -> CFString {
-            CFString::new("stub")
+        fn uuid_for_rect(&self, _rect: CGRect) -> CFRetained<CFString> {
+            CFString::from_static_str("stub")
         }
     }
 

--- a/src/sys/window_server.rs
+++ b/src/sys/window_server.rs
@@ -3,31 +3,28 @@
 
 use std::ffi::{c_int, c_void};
 use std::marker::PhantomData;
+use std::ptr;
 
 use accessibility::AXUIElement;
 use accessibility_sys::pid_t;
-use core_foundation::array::CFArray;
-use core_foundation::base::{CFType, CFTypeRef, ItemRef, TCFType};
-use core_foundation::boolean::CFBoolean;
-use core_foundation::dictionary::CFDictionary;
-use core_foundation::number::CFNumber;
-use core_foundation::string::{CFString, CFStringRef};
 use core_graphics::base::CGError;
-use core_graphics::display::CGWindowListCopyWindowInfo;
-use core_graphics::window::{
-    CGWindowID, CGWindowListCreateDescriptionFromArray, kCGNullWindowID, kCGWindowBounds,
-    kCGWindowLayer, kCGWindowListExcludeDesktopElements, kCGWindowListOptionOnScreenOnly,
-    kCGWindowNumber, kCGWindowOwnerPID,
-};
 use objc2_app_kit::NSWindow;
-use objc2_core_foundation::{CGPoint, CGRect};
+use objc2_core_foundation::{
+    CFArray, CFBoolean, CFDictionary, CFIndex, CFNumber, CFRetained, CFString, CFType, CGPoint,
+    CGRect, CGSize,
+};
+use objc2_core_graphics::{
+    CGRectMakeWithDictionaryRepresentation, CGWindowID, CGWindowListCopyWindowInfo,
+    CGWindowListCreateDescriptionFromArray, CGWindowListOption, kCGNullWindowID, kCGWindowBounds,
+    kCGWindowLayer, kCGWindowNumber, kCGWindowOwnerPID,
+};
 use objc2_foundation::MainThreadMarker;
 use serde::{Deserialize, Serialize};
 use sorted_vec::SortedVec;
 use static_assertions::assert_not_impl_any;
 use tracing::warn;
 
-use super::geometry::{CGRectDef, ToICrate};
+use super::geometry::CGRectDef;
 use super::screen::CoordinateConverter;
 use crate::sys::app::ProcessSerialNumber;
 
@@ -115,21 +112,21 @@ pub fn get_visible_window_ids() -> Vec<WindowServerId> {
 
 /// Returns a list of windows visible on the screen, in order starting with the
 /// frontmost.
-pub fn get_visible_windows_raw() -> CFArray<CFDictionary<CFString, CFType>> {
+pub fn get_visible_windows_raw() -> CFRetained<CFArray<CFDictionary<CFString, CFType>>> {
     // Note that the ordering is not documented. But
     // NSWindow::windowNumbersWithOptions *is* documented to return the windows
     // in order, so we could always combine their information if the behavior
     // changed.
-    unsafe {
-        CFArray::wrap_under_get_rule(CGWindowListCopyWindowInfo(
-            kCGWindowListOptionOnScreenOnly | kCGWindowListExcludeDesktopElements,
-            kCGNullWindowID,
-        ))
-    }
+    let options =
+        CGWindowListOption::OptionOnScreenOnly | CGWindowListOption::ExcludeDesktopElements;
+    let array = CGWindowListCopyWindowInfo(options, kCGNullWindowID)
+        .expect("CGWindowListCopyWindowInfo returned NULL");
+    // SAFETY: CGWindowListCopyWindowInfo returns an array of window info dicts.
+    unsafe { CFRetained::cast_unchecked(array) }
 }
 
 fn make_info(
-    win: ItemRef<CFDictionary<CFString, CFType>>,
+    win: CFRetained<CFDictionary<CFString, CFType>>,
     layer_filter: Option<i32>,
 ) -> Option<WindowServerInfo> {
     let layer = get_num(&win, unsafe { kCGWindowLayer })?.try_into().ok()?;
@@ -138,13 +135,21 @@ fn make_info(
     }
     let id = get_num(&win, unsafe { kCGWindowNumber })?;
     let pid = get_num(&win, unsafe { kCGWindowOwnerPID })?;
-    let frame: CFDictionary = win.find(unsafe { kCGWindowBounds })?.downcast()?;
-    let frame = core_graphics_types::geometry::CGRect::from_dict_representation(&frame)?;
+    let frame_dict: CFRetained<CFDictionary> =
+        win.get(unsafe { kCGWindowBounds })?.downcast().ok()?;
+    let mut frame = CGRect {
+        origin: CGPoint { x: 0.0, y: 0.0 },
+        size: CGSize { width: 0.0, height: 0.0 },
+    };
+    // SAFETY: `frame_dict` and `&mut frame` are valid for the duration of this call.
+    if !unsafe { CGRectMakeWithDictionaryRepresentation(Some(&frame_dict), &mut frame) } {
+        return None;
+    }
     Some(WindowServerInfo {
         id: WindowServerId(id.try_into().ok()?),
         pid: pid.try_into().ok()?,
         layer,
-        frame: frame.to_icrate(),
+        frame,
     })
 }
 
@@ -159,18 +164,30 @@ pub fn get_window(id: WindowServerId) -> Option<WindowServerInfo> {
     get_windows_inner(&[id]).iter().next().and_then(|w| make_info(w, None))
 }
 
-fn get_windows_inner(ids: &[WindowServerId]) -> CFArray<CFDictionary<CFString, CFType>> {
-    let array = CFArray::from_copyable(ids);
-    unsafe {
-        CFArray::wrap_under_create_rule(CGWindowListCreateDescriptionFromArray(
-            array.as_concrete_TypeRef(),
-        ))
+fn get_windows_inner(
+    ids: &[WindowServerId],
+) -> CFRetained<CFArray<CFDictionary<CFString, CFType>>> {
+    // SAFETY: `ids` outlives this call, and `CGWindowListCreateDescriptionFromArray`
+    // reads it as an array of raw (non-retained) `CGWindowID` values, matching how
+    // the array is constructed here (no retain/release callbacks).
+    let array = unsafe {
+        CFArray::new(
+            None,
+            ids.as_ptr() as *mut *const c_void,
+            ids.len() as CFIndex,
+            ptr::null(),
+        )
     }
+    .expect("CFArrayCreate returned NULL");
+    let described = unsafe { CGWindowListCreateDescriptionFromArray(Some(&array)) }
+        .expect("CGWindowListCreateDescriptionFromArray returned NULL");
+    // SAFETY: CGWindowListCreateDescriptionFromArray returns an array of window
+    // info dicts.
+    unsafe { CFRetained::cast_unchecked(described) }
 }
 
-fn get_num(dict: &CFDictionary<CFString, CFType>, key: CFStringRef) -> Option<i64> {
-    let item: CFNumber = dict.find(key)?.downcast()?;
-    Some(item.to_i64()?)
+fn get_num(dict: &CFDictionary<CFString, CFType>, key: &CFString) -> Option<i64> {
+    dict.get(key)?.downcast::<CFNumber>().ok()?.as_i64()
 }
 
 pub fn get_window_at_point(
@@ -393,15 +410,8 @@ pub const kCGSWindowIsTerminated: u32 = 804;
 /// discussed by Apple engineers on developer forums.
 pub fn allow_hide_mouse() -> Result<(), CGError> {
     let cid = unsafe { CGSMainConnectionID() };
-    let property = CFString::from_static_string("SetsCursorInBackground");
-    check(unsafe {
-        CGSSetConnectionProperty(
-            cid,
-            cid,
-            property.as_concrete_TypeRef(),
-            CFBoolean::true_value().as_CFTypeRef(),
-        )
-    })
+    let property = CFString::from_static_str("SetsCursorInBackground");
+    check(unsafe { CGSSetConnectionProperty(cid, cid, &property, CFBoolean::new(true)) })
 }
 
 type CGSConnectionID = c_int;
@@ -412,7 +422,7 @@ unsafe extern "C" {
     fn CGSSetConnectionProperty(
         cid: CGSConnectionID,
         target_cid: CGSConnectionID,
-        key: CFStringRef,
-        value: CFTypeRef,
+        key: &CFString,
+        value: &CFType,
     ) -> CGError;
 }

--- a/src/sys/window_server.rs
+++ b/src/sys/window_server.rs
@@ -5,7 +5,7 @@ use std::ffi::{c_int, c_void};
 use std::marker::PhantomData;
 
 use accessibility::AXUIElement;
-use accessibility_sys::{AXError, AXUIElementRef, kAXErrorSuccess, pid_t};
+use accessibility_sys::pid_t;
 use core_foundation::array::CFArray;
 use core_foundation::base::{CFType, CFTypeRef, ItemRef, TCFType};
 use core_foundation::boolean::CFBoolean;
@@ -59,9 +59,9 @@ impl TryFrom<&AXUIElement> for WindowServerId {
     type Error = accessibility::Error;
     fn try_from(element: &AXUIElement) -> Result<Self, accessibility::Error> {
         let mut id = 0;
-        let res = unsafe { _AXUIElementGetWindow(element.as_concrete_TypeRef(), &mut id) };
-        if res != kAXErrorSuccess {
-            return Err(accessibility::Error::Ax(res));
+        let res = unsafe { _AXUIElementGetWindow(element.as_sys(), &mut id) };
+        if let Some(err) = accessibility::AXError::from_raw(res) {
+            return Err(accessibility::Error::Ax(err));
         }
         Ok(WindowServerId(id))
     }
@@ -184,7 +184,10 @@ pub fn get_window_at_point(
 }
 
 unsafe extern "C" {
-    fn _AXUIElementGetWindow(elem: AXUIElementRef, wid: *mut CGWindowID) -> AXError;
+    fn _AXUIElementGetWindow(
+        elem: &accessibility_sys::AXUIElement,
+        wid: *mut CGWindowID,
+    ) -> accessibility_sys::AXError;
 }
 
 /// Set the key window of the window server and application.

--- a/src/ui/permission_flow.rs
+++ b/src/ui/permission_flow.rs
@@ -7,16 +7,13 @@ use std::thread::sleep;
 use std::time::Duration;
 
 use accessibility_sys::{AXIsProcessTrustedWithOptions, kAXTrustedCheckOptionPrompt};
-use core_foundation::base::TCFType;
-use core_foundation::boolean::CFBoolean;
-use core_foundation::string::CFString;
-use core_graphics::display::CFDictionary;
 use objc2::rc::Retained;
 use objc2::{MainThreadMarker, MainThreadOnly, define_class, msg_send, sel};
 use objc2_app_kit::{
     NSAlert, NSAlertFirstButtonReturn, NSAlertSecondButtonReturn, NSApplicationActivationOptions,
     NSButton, NSRunningApplication,
 };
+use objc2_core_foundation::{CFBoolean, CFDictionary};
 use objc2_foundation::{NSObject, NSString, ns_string};
 use tracing::{error, info, warn};
 
@@ -125,11 +122,11 @@ impl RequestAXPermissionsAction {
 }
 
 fn check_ax(prompt: bool) -> bool {
-    let options = CFDictionary::from_CFType_pairs(&[(
-        unsafe { CFString::wrap_under_create_rule(kAXTrustedCheckOptionPrompt) },
-        CFBoolean::from(prompt),
-    )]);
-    unsafe { AXIsProcessTrustedWithOptions(options.as_concrete_TypeRef()) }
+    // SAFETY: `kAXTrustedCheckOptionPrompt` is a valid static CFString.
+    let key = unsafe { kAXTrustedCheckOptionPrompt };
+    let options = CFDictionary::from_slices(&[key], &[CFBoolean::new(prompt)]);
+    // SAFETY: `options` is a valid dictionary of the expected type.
+    unsafe { AXIsProcessTrustedWithOptions(Some(options.as_ref())) }
 }
 
 fn raise_dialog() {


### PR DESCRIPTION
This removes dependence on the deprecated `block` crate, which will stop compiling in a future version of Rust.

The only remaining dependence on core-foundation after this is the event tap code for the mouse.