### PR TITLE
Fix focus flicker after `NSApplicationDidChangeScreenParametersNotification` storm

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -85,6 +85,16 @@ Each window has a `TransactionId` tracking the last write. Stale reads from app 
 - **Incrementalism** – avoid global initialization/discovery steps; adapt to new info from each app as it becomes available
 - **Policy decisions in LayoutManager** – refutable policy decisions, e.g. defaulting certain windows to floating, go through LayoutManager's classification, not scattered across Reactor/App
 
+## Comments
+
+Comments say what the code does. Explain why only when the reason isn't clear
+from the surrounding code and this document, or when the logic is subtle enough
+that a reader would otherwise assume it's wrong.
+
+Don't argue for a change in a comment. A comment is read by someone who has only
+ever seen the current code, so justifying it against what was there before, or
+against an alternative that was considered, is noise.
+
 ## Testing Patterns
 
 - **Model tests**: Construct a tree, perform operations, assert exact pixel-level frames. No mocking or timing needed.
@@ -116,5 +126,10 @@ Fixes #12345.
 ```
 
 Features should include a short user-facing blurb for the release notes summarizing the feature and how to use it.
+
+Keep the body short: what was wrong and what the change does. Defend the change
+only when it reverses an earlier decision, or when it's subtle enough that a
+reviewer would otherwise think it's wrong. Weighing alternatives, restating what
+the diff plainly shows, and noting the absence of tests are all noise.
 
 Non user-facing changes can use `refactor`, `internal`, `chore`, `build`, `ci`, `style`, `test`, or skip the prefix if none apply.

--- a/src/actor/raise.rs
+++ b/src/actor/raise.rs
@@ -44,6 +44,14 @@ pub struct RaiseRequest {
     pub app_handles: HashMap<i32, AppThreadHandle>,
 }
 
+impl RaiseRequest {
+    /// Whether this request asks for the same thing as `other`. App handles
+    /// aren't compared; they don't affect what the request does.
+    fn matches(&self, other: &RaiseRequest) -> bool {
+        self.raise_windows == other.raise_windows && self.focus_window == other.focus_window
+    }
+}
+
 pub struct RaiseManager {
     /// The currently active sequence, if any
     active_sequence: Option<ActiveSequence>,
@@ -136,22 +144,18 @@ impl RaiseManager {
 
     fn handle_message(&mut self, msg: Event) {
         match msg {
-            Event::RaiseRequest(RaiseRequest {
-                raise_windows,
-                focus_window,
-                app_handles,
-            }) => {
+            Event::RaiseRequest(request) => {
                 debug!(
                     "Processing layout response with {} raise_windows",
-                    raise_windows.len()
+                    request.raise_windows.len()
                 );
 
-                // Always queue the sequence
-                self.queued_sequences.push_back(RaiseRequest {
-                    raise_windows,
-                    focus_window,
-                    app_handles,
-                });
+                // Drop duplicate requests that have no effect.
+                if self.queued_sequences.back().is_some_and(|last| last.matches(&request)) {
+                    debug!("Dropping raise request identical to the queued one");
+                } else {
+                    self.queued_sequences.push_back(request);
+                }
             }
             Event::RaiseCompleted { window_id, sequence_id } => {
                 trace!("Raise completed for {:?} in sequence {}", window_id, sequence_id);
@@ -364,6 +368,20 @@ mod tests {
             focus_window,
             app_handles,
         })
+    }
+
+    /// What each queued request will do, oldest first.
+    fn queued(raise_manager: &RaiseManager) -> Vec<(Vec<Vec<WindowId>>, Option<WindowId>)> {
+        raise_manager
+            .queued_sequences
+            .iter()
+            .map(|request| {
+                (
+                    request.raise_windows.clone(),
+                    request.focus_window.map(|(wid, _)| wid),
+                )
+            })
+            .collect()
     }
 
     fn collect_requests(app_rx: &mut mpsc::UnboundedReceiver<(Span, Request)>) -> Vec<Request> {
@@ -632,6 +650,35 @@ mod tests {
                 sequence_id: 1,
             });
             assert!(raise_manager.active_sequence.is_none());
+        });
+    }
+
+    #[test]
+    fn test_identical_requests_collapse_to_one_queued() {
+        Executor::run(async {
+            let mut raise_manager = RaiseManager::new();
+            let (app_handles, _app_rx) = create_test_app_handles();
+            let request = || {
+                create_layout_response(
+                    vec![WindowId::new(1, 1), WindowId::new(1, 2)],
+                    Some((WindowId::new(1, 3), None)),
+                    app_handles.clone(),
+                )
+            };
+
+            // The first becomes active; the rest would pile up behind it.
+            for _ in 0..10 {
+                raise_manager.handle_message(request());
+            }
+
+            assert_eq!(raise_manager.active_sequence.as_ref().unwrap().sequence_id, 1);
+            assert_eq!(
+                queued(&raise_manager),
+                vec![(
+                    vec![vec![WindowId::new(1, 1)], vec![WindowId::new(1, 2)]],
+                    Some(WindowId::new(1, 3))
+                )]
+            );
         });
     }
 

--- a/src/actor/reactor.rs
+++ b/src/actor/reactor.rs
@@ -70,6 +70,7 @@ pub enum Event {
         spaces: Vec<Option<SpaceId>>,
         scale_factors: Vec<f64>,
         converter: CoordinateConverter,
+        on_screen: WindowsOnScreen,
     },
 
     /// The current space changed.
@@ -234,6 +235,20 @@ struct AppState {
     #[allow(unused)]
     pub info: AppInfo,
     pub handle: AppThreadHandle,
+}
+
+/// Extra information about the event a layout response came from.
+#[derive(Default)]
+struct ResponseContext {
+    /// The windows visible on screen, front to back, from a snapshot taken with
+    /// the event. `None` if the event didn't come with one.
+    ///
+    /// Only valid for the event it arrived with: raising windows changes the
+    /// order and the window server doesn't report the result.
+    visible_window_order: Option<Vec<WindowServerId>>,
+    /// Whether the event came from the mouse moving, in which case we don't
+    /// warp the mouse to the newly focused window.
+    from_mouse: bool,
 }
 
 #[derive(Copy, Clone, Debug)]
@@ -570,18 +585,38 @@ impl Reactor {
                 spaces,
                 converter,
                 scale_factors,
+                on_screen,
             } => {
                 info!("screen parameters changed");
+                let visible_window_order = on_screen.visible.clone();
+                self.update_complete_window_server_info(on_screen);
                 self.screens = frames
                     .into_iter()
                     .zip(spaces.clone())
                     .zip(scale_factors)
                     .map(|((frame, space), scale_factor)| Screen { frame, space, scale_factor })
                     .collect();
-                let screens = self.screens.clone();
-                for screen in screens {
-                    let Some(space) = screen.space else { continue };
-                    self.send_layout_event(LayoutEvent::SpaceExposed(space, screen.frame.size));
+                let response = self
+                    .screens
+                    .iter()
+                    .filter_map(|screen| screen.space.map(|space| (space, screen.frame.size)))
+                    .collect::<Vec<_>>()
+                    .into_iter()
+                    .map(|(space, size)| {
+                        self.layout.handle_event(LayoutEvent::SpaceExposed(space, size))
+                    })
+                    .reduce(layout::EventResponse::coalesce);
+                if let Some(response) = response {
+                    self.handle_layout_response_with_context(
+                        response,
+                        ResponseContext {
+                            visible_window_order: Some(visible_window_order),
+                            ..Default::default()
+                        },
+                    );
+                    for space in self.screens.iter().flat_map(|screen| screen.space) {
+                        self.layout.debug_tree_desc(space, "after event", false);
+                    }
                 }
                 self.update_active_screen();
                 // FIXME: Update visible windows if space changed.
@@ -593,7 +628,7 @@ impl Reactor {
                     .send(group_bars::Event::ScreenParametersChanged(spaces, converter));
             }
             Event::SpaceChanged(spaces, on_screen) => {
-                let visible_window_order = on_screen.visible.iter().copied().collect::<Vec<_>>();
+                let visible_window_order = on_screen.visible.clone();
                 self.update_complete_window_server_info(on_screen);
                 if spaces.len() != self.screens.len() {
                     warn!(
@@ -618,10 +653,12 @@ impl Reactor {
                     })
                     .reduce(layout::EventResponse::coalesce);
                 if let Some(response) = response {
-                    self.handle_layout_response_with_visible_window_order(
+                    self.handle_layout_response_with_context(
                         response,
-                        Some(&visible_window_order),
-                        false,
+                        ResponseContext {
+                            visible_window_order: Some(visible_window_order),
+                            ..Default::default()
+                        },
                     );
                     for space in self.screens.iter().flat_map(|screen| screen.space) {
                         self.layout.debug_tree_desc(space, "after event", false);
@@ -689,12 +726,15 @@ impl Reactor {
                     (Some(space), Some(id)) => Some((space, id)),
                     _ => None,
                 };
-                self.send_layout_event_from_mouse(
+                self.send_layout_event_with_context(
                     LayoutEvent::MouseMovedOverWindow {
                         over: (to_space, wid),
                         current_main,
                     },
-                    true,
+                    ResponseContext {
+                        from_mouse: true,
+                        ..Default::default()
+                    },
                 );
             }
             Event::RaiseCompleted { window_id, sequence_id } => {
@@ -941,62 +981,31 @@ impl Reactor {
     }
 
     fn send_layout_event(&mut self, event: LayoutEvent) {
-        self.send_layout_event_with_visible_window_order(event, &[]);
+        self.send_layout_event_with_context(event, ResponseContext::default());
     }
 
-    fn send_layout_event_with_visible_window_order(
-        &mut self,
-        event: LayoutEvent,
-        visible_window_order: &[WindowServerId],
-    ) {
-        self.send_layout_event_with_visible_window_order_from_mouse(
-            event,
-            visible_window_order,
-            false,
-        );
-    }
-
-    fn send_layout_event_from_mouse(&mut self, event: LayoutEvent, from_mouse: bool) {
-        self.send_layout_event_with_visible_window_order_from_mouse(event, &[], from_mouse);
-    }
-
-    fn send_layout_event_with_visible_window_order_from_mouse(
-        &mut self,
-        event: LayoutEvent,
-        visible_window_order: &[WindowServerId],
-        from_mouse: bool,
-    ) {
+    fn send_layout_event_with_context(&mut self, event: LayoutEvent, context: ResponseContext) {
         let response = self.layout.handle_event(event);
-        self.handle_layout_response_with_visible_window_order(
-            response,
-            (!visible_window_order.is_empty()).then_some(visible_window_order),
-            from_mouse,
-        );
+        self.handle_layout_response_with_context(response, context);
         for space in self.screens.iter().flat_map(|screen| screen.space) {
             self.layout.debug_tree_desc(space, "after event", false);
         }
     }
 
     fn handle_layout_response(&mut self, response: layout::EventResponse) {
-        self.handle_layout_response_from_mouse(response, false);
+        self.handle_layout_response_with_context(response, ResponseContext::default());
     }
 
-    fn handle_layout_response_from_mouse(
-        &mut self,
-        response: layout::EventResponse,
-        from_mouse: bool,
-    ) {
-        self.handle_layout_response_with_visible_window_order(response, None, from_mouse);
-    }
-
-    fn handle_layout_response_with_visible_window_order(
+    fn handle_layout_response_with_context(
         &mut self,
         mut response: layout::EventResponse,
-        visible_window_order: Option<&[WindowServerId]>,
-        from_mouse: bool,
+        ResponseContext {
+            visible_window_order,
+            from_mouse,
+        }: ResponseContext,
     ) {
         if let Some(visible_window_order) = visible_window_order {
-            response = self.filter_response(response, visible_window_order);
+            response = self.filter_response(response, &visible_window_order);
         }
 
         let layout::EventResponse {
@@ -1190,6 +1199,7 @@ pub mod tests {
             spaces: vec![Some(SpaceId::new(1))],
             scale_factors: vec![2.0],
             converter: CoordinateConverter::default(),
+            on_screen: Default::default(),
         });
 
         reactor.handle_events(apps.make_app(1, make_windows(2)));
@@ -1221,6 +1231,7 @@ pub mod tests {
             spaces: vec![Some(SpaceId::new(1))],
             scale_factors: vec![2.0],
             converter: CoordinateConverter::default(),
+            on_screen: Default::default(),
         });
 
         reactor.handle_events(apps.make_app(1, make_windows(2)));
@@ -1250,6 +1261,7 @@ pub mod tests {
             spaces: vec![Some(space)],
             scale_factors: vec![2.0],
             converter: CoordinateConverter::default(),
+            on_screen: Default::default(),
         });
         reactor.handle_events(apps.make_app_with_opts(1, make_windows(1), Some(wid), true));
         reactor.handle_event(Event::ApplicationGloballyActivated(1));
@@ -1305,6 +1317,7 @@ pub mod tests {
             spaces: vec![Some(space)],
             scale_factors: vec![2.0],
             converter: CoordinateConverter::default(),
+            on_screen: Default::default(),
         });
         reactor.handle_events(apps.make_app_with_opts(1, make_windows(1), Some(wid), true));
         reactor.handle_event(Event::ApplicationGloballyActivated(1));
@@ -1336,6 +1349,7 @@ pub mod tests {
             spaces: vec![Some(SpaceId::new(1))],
             scale_factors: vec![2.0],
             converter: CoordinateConverter::default(),
+            on_screen: Default::default(),
         });
 
         reactor.handle_events(apps.make_app(1, make_windows(2)));
@@ -1374,6 +1388,7 @@ pub mod tests {
             spaces: vec![Some(SpaceId::new(1))],
             scale_factors: vec![2.0],
             converter: CoordinateConverter::default(),
+            on_screen: Default::default(),
         });
 
         reactor.handle_events(apps.make_app(1, make_windows(2)));
@@ -1416,6 +1431,7 @@ pub mod tests {
             spaces: vec![Some(SpaceId::new(1))],
             scale_factors: vec![2.0],
             converter: CoordinateConverter::default(),
+            on_screen: Default::default(),
         });
 
         reactor.handle_events(apps.make_app(1, make_windows(3)));
@@ -1465,6 +1481,7 @@ pub mod tests {
             spaces: vec![Some(SpaceId::new(1))],
             scale_factors: vec![2.0],
             converter: CoordinateConverter::default(),
+            on_screen: Default::default(),
         });
 
         reactor.handle_events(apps.make_app(1, make_windows(1)));
@@ -1495,6 +1512,7 @@ pub mod tests {
             spaces: vec![None],
             scale_factors: vec![2.0],
             converter: CoordinateConverter::default(),
+            on_screen: Default::default(),
         });
         reactor.handle_event(Event::WindowsOnScreenUpdated {
             pid: None,
@@ -1523,6 +1541,90 @@ pub mod tests {
     }
 
     #[test]
+    fn it_skips_surface_on_screen_change_when_top_layer_order_matches() {
+        let mut apps = Apps::new();
+        let mut reactor = Reactor::new_for_test(LayoutManager::new());
+        let (raise_manager_tx, mut raise_manager_rx) = mpsc::unbounded_channel();
+        reactor.raise_manager_tx = raise_manager_tx;
+        let space = SpaceId::new(1);
+        reactor.handle_event(Event::ScreenParametersChanged {
+            frames: vec![CGRect::new(CGPoint::new(0., 0.), CGSize::new(1000., 1000.))],
+            spaces: vec![Some(space)],
+            scale_factors: vec![2.0],
+            converter: CoordinateConverter::default(),
+            on_screen: Default::default(),
+        });
+        reactor.handle_events(apps.make_app_with_opts(1, make_windows(2), None, false));
+        let _events = apps.simulate_events();
+        while raise_manager_rx.try_recv().is_ok() {}
+
+        // A screen change that doesn't disturb the stacking shouldn't restack.
+        let desired = reactor
+            .layout
+            .handle_event(LayoutEvent::SpaceExposed(space, CGSize::new(1000., 900.)))
+            .raise_windows;
+        let on_screen = desired
+            .iter()
+            .map(|wid| WindowServerInfo {
+                id: reactor.windows[wid].window_server_id.unwrap(),
+                pid: wid.pid,
+                layer: 0,
+                frame: reactor.windows[wid].frame_monotonic,
+            })
+            .collect();
+        reactor.handle_event(Event::ScreenParametersChanged {
+            frames: vec![CGRect::new(CGPoint::new(0., 0.), CGSize::new(1000., 900.))],
+            spaces: vec![Some(space)],
+            scale_factors: vec![2.0],
+            converter: CoordinateConverter::default(),
+            on_screen: WindowsOnScreen::new(on_screen),
+        });
+        assert!(raise_manager_rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn it_surfaces_on_screen_change_when_another_window_is_in_front() {
+        let mut apps = Apps::new();
+        let mut reactor = Reactor::new_for_test(LayoutManager::new());
+        let (raise_manager_tx, mut raise_manager_rx) = mpsc::unbounded_channel();
+        reactor.raise_manager_tx = raise_manager_tx;
+        let space = SpaceId::new(1);
+        reactor.handle_event(Event::ScreenParametersChanged {
+            frames: vec![CGRect::new(CGPoint::new(0., 0.), CGSize::new(1000., 1000.))],
+            spaces: vec![Some(space)],
+            scale_factors: vec![2.0],
+            converter: CoordinateConverter::default(),
+            on_screen: Default::default(),
+        });
+        reactor.handle_events(apps.make_app_with_opts(1, make_windows(2), None, false));
+        let _events = apps.simulate_events();
+        while raise_manager_rx.try_recv().is_ok() {}
+
+        // An unmanaged window is in front of the ones the layout wants on top,
+        // so the restack is still needed.
+        let mut on_screen = vec![WindowServerInfo {
+            id: WindowServerId::new(999),
+            pid: 2,
+            layer: 0,
+            frame: CGRect::new(CGPoint::new(0., 0.), CGSize::new(100., 100.)),
+        }];
+        on_screen.extend(reactor.windows.iter().map(|(wid, window)| WindowServerInfo {
+            id: window.window_server_id.unwrap(),
+            pid: wid.pid,
+            layer: 0,
+            frame: window.frame_monotonic,
+        }));
+        reactor.handle_event(Event::ScreenParametersChanged {
+            frames: vec![CGRect::new(CGPoint::new(0., 0.), CGSize::new(1000., 900.))],
+            spaces: vec![Some(space)],
+            scale_factors: vec![2.0],
+            converter: CoordinateConverter::default(),
+            on_screen: WindowsOnScreen::new(on_screen),
+        });
+        assert!(raise_manager_rx.try_recv().is_ok());
+    }
+
+    #[test]
     fn it_skips_surface_when_top_layer_order_matches() {
         let mut apps = Apps::new();
         let mut reactor = Reactor::new_for_test(LayoutManager::new());
@@ -1534,6 +1636,7 @@ pub mod tests {
             spaces: vec![Some(space)],
             scale_factors: vec![2.0],
             converter: CoordinateConverter::default(),
+            on_screen: Default::default(),
         });
         reactor.handle_events(apps.make_app_with_opts(1, make_windows(2), None, false));
         let _events = apps.simulate_events();
@@ -1572,6 +1675,7 @@ pub mod tests {
             spaces: vec![Some(space)],
             scale_factors: vec![2.0],
             converter: CoordinateConverter::default(),
+            on_screen: Default::default(),
         });
         reactor.handle_events(apps.make_app_with_opts(1, make_windows(2), None, false));
         let _events = apps.simulate_events();
@@ -1611,6 +1715,7 @@ pub mod tests {
             spaces: vec![Some(space)],
             scale_factors: vec![2.0],
             converter: CoordinateConverter::default(),
+            on_screen: Default::default(),
         });
         reactor.handle_events(apps.make_app_with_opts(1, make_windows(2), None, false));
         let _events = apps.simulate_events();
@@ -1752,6 +1857,7 @@ pub mod tests {
             spaces: vec![Some(space)],
             scale_factors: vec![2.0],
             converter: CoordinateConverter::default(),
+            on_screen: Default::default(),
         });
         reactor.handle_events(apps.make_app_with_opts(1, make_windows(2), None, false));
         let _events = apps.simulate_events();
@@ -1799,6 +1905,7 @@ pub mod tests {
             spaces: vec![None],
             scale_factors: vec![2.0],
             converter: CoordinateConverter::default(),
+            on_screen: Default::default(),
         });
 
         reactor.handle_events(apps.make_app(1, make_windows(1)));
@@ -1828,6 +1935,7 @@ pub mod tests {
             spaces: vec![Some(SpaceId::new(1)), Some(SpaceId::new(2))],
             scale_factors: vec![2.0, 2.0],
             converter: CoordinateConverter::default(),
+            on_screen: Default::default(),
         });
 
         let mut windows = make_windows(2);
@@ -1858,6 +1966,7 @@ pub mod tests {
             spaces: vec![Some(space1), Some(space2)],
             scale_factors: vec![2.0, 2.0],
             converter: CoordinateConverter::default(),
+            on_screen: Default::default(),
         });
 
         // Both windows start on screen1 / space1.
@@ -1934,6 +2043,7 @@ pub mod tests {
             spaces: vec![Some(space1), Some(space2)],
             scale_factors: vec![2.0, 2.0],
             converter: CoordinateConverter::default(),
+            on_screen: Default::default(),
         });
 
         reactor.handle_events(apps.make_app(1, make_windows(2)));
@@ -1982,6 +2092,7 @@ pub mod tests {
             spaces: vec![Some(SpaceId::new(1))],
             scale_factors: vec![2.0],
             converter: CoordinateConverter::default(),
+            on_screen: Default::default(),
         });
         reactor.handle_event(Event::WindowsOnScreenUpdated {
             pid: None,
@@ -2023,6 +2134,7 @@ pub mod tests {
             spaces: vec![Some(SpaceId::new(1)), Some(SpaceId::new(2))],
             scale_factors: vec![2.0, 2.0],
             converter: CoordinateConverter::default(),
+            on_screen: Default::default(),
         });
 
         reactor.handle_events(apps.make_app(1, make_windows(2)));
@@ -2105,6 +2217,7 @@ pub mod tests {
             spaces: vec![Some(space)],
             scale_factors: vec![2.0],
             converter: CoordinateConverter::default(),
+            on_screen: Default::default(),
         });
 
         reactor.handle_events(apps.make_app_with_opts(
@@ -2131,12 +2244,14 @@ pub mod tests {
             spaces: vec![None],
             scale_factors: vec![2.0],
             converter: CoordinateConverter::default(),
+            on_screen: Default::default(),
         });
         reactor.handle_event(Event::ScreenParametersChanged {
             frames: vec![full_screen],
             spaces: vec![Some(space)],
             scale_factors: vec![2.0],
             converter: CoordinateConverter::default(),
+            on_screen: Default::default(),
         });
         reactor.handle_event(Event::WindowsOnScreenUpdated {
             pid: None,
@@ -2190,6 +2305,7 @@ pub mod tests {
             spaces: vec![Some(SpaceId::new(1))],
             scale_factors: vec![2.0],
             converter: CoordinateConverter::default(),
+            on_screen: Default::default(),
         });
 
         reactor.handle_events(apps.make_app(1, make_windows(1)));
@@ -2211,6 +2327,7 @@ pub mod tests {
             spaces: vec![Some(SpaceId::new(1)), None],
             scale_factors: vec![2.0, 2.0],
             converter: CoordinateConverter::default(),
+            on_screen: Default::default(),
         });
         reactor.handle_event(Event::WindowsOnScreenUpdated {
             pid: None,
@@ -2245,6 +2362,7 @@ pub mod tests {
             spaces: vec![Some(space)],
             scale_factors: vec![2.0],
             converter: CoordinateConverter::default(),
+            on_screen: Default::default(),
         });
         assert_eq!(None, reactor.main_window());
 
@@ -2277,6 +2395,7 @@ pub mod tests {
             spaces: vec![Some(space)],
             scale_factors: vec![2.0],
             converter: CoordinateConverter::default(),
+            on_screen: Default::default(),
         });
         reactor.handle_event(ApplicationGloballyActivated(1));
         reactor.handle_events(apps.make_app_with_opts(
@@ -2319,6 +2438,7 @@ pub mod tests {
             spaces: vec![Some(space)],
             scale_factors: vec![2.0],
             converter: CoordinateConverter::default(),
+            on_screen: Default::default(),
         });
         reactor1.handle_events(apps.make_app(1, make_windows(2)));
         reactor1.handle_events(apps.make_app(2, make_windows(2)));
@@ -2342,6 +2462,7 @@ pub mod tests {
             spaces: vec![Some(space)],
             scale_factors: vec![2.0],
             converter: CoordinateConverter::default(),
+            on_screen: Default::default(),
         });
         // Only apps 1 and 3 launch during restore (app 2 was terminated between save and restore)
         reactor2.handle_events(apps2.make_app(1, make_windows(2)));
@@ -2386,6 +2507,7 @@ pub mod tests {
             spaces: vec![Some(space)],
             scale_factors: vec![2.0],
             converter: CoordinateConverter::default(),
+            on_screen: Default::default(),
         });
 
         let mut apps = Apps::new();

--- a/src/actor/reactor.rs
+++ b/src/actor/reactor.rs
@@ -1059,36 +1059,32 @@ impl Reactor {
         mut response: layout::EventResponse,
         mut visible_window_order: &[WindowServerId],
     ) -> layout::EventResponse {
-        // For now, just optimize the case where the response is a no-op.
         if let Some(focus) = response.focus_window {
+            // Attempt to match out the focus window with the top visible window.
             if let Some(&first) = visible_window_order.first()
                 && focus.wsid() == Some(first)
             {
-                // Note that we keep the focus window in the request unless
+                // Note that we keep the focus window in the request, unless
                 // there are no raise windows.
                 visible_window_order = &visible_window_order[1..];
             } else {
                 return response;
             }
-        }
+        };
         let desired_visible_wsids = response
             .raise_windows
             .iter()
-            .flat_map(|wid| {
-                self.windows
-                    .get(wid)
-                    .and_then(|window| window.window_server_id)
-                    .filter(|wsid| self.visible_windows.contains(wsid))
-                    .filter(|wsid| self.should_compare_visible_window(*wsid))
-            })
+            .flat_map(|wid| self.windows.get(wid).and_then(|window| window.window_server_id))
             .collect::<HashSet<_>>();
         let current_top_wsids = visible_window_order
             .iter()
             .copied()
+            // Filter out off-screen windows and windows on non-zero layers.
             .filter(|wsid| self.should_compare_visible_window(*wsid))
             .take(desired_visible_wsids.len())
             .collect::<HashSet<_>>();
 
+        // Optimize the case where the response is a no-op.
         if current_top_wsids == desired_visible_wsids {
             response.focus_window.take();
             response.raise_windows.clear();
@@ -1538,6 +1534,70 @@ pub mod tests {
             reactor.layout.selected_window(SpaceId::new(1)),
             Some(WindowId::new(1, 1))
         );
+    }
+
+    #[test]
+    fn it_surfaces_on_screen_change_when_the_snapshot_is_empty() {
+        let mut apps = Apps::new();
+        let mut reactor = Reactor::new_for_test(LayoutManager::new());
+        let (raise_manager_tx, mut raise_manager_rx) = mpsc::unbounded_channel();
+        reactor.raise_manager_tx = raise_manager_tx;
+        let space = SpaceId::new(1);
+        reactor.handle_event(Event::ScreenParametersChanged {
+            frames: vec![CGRect::new(CGPoint::new(0., 0.), CGSize::new(1000., 1000.))],
+            spaces: vec![Some(space)],
+            scale_factors: vec![2.0],
+            converter: CoordinateConverter::default(),
+            on_screen: Default::default(),
+        });
+        reactor.handle_events(apps.make_app_with_opts(1, make_windows(2), None, false));
+        let _events = apps.simulate_events();
+        while raise_manager_rx.try_recv().is_ok() {}
+
+        reactor.handle_event(Event::ScreenParametersChanged {
+            frames: vec![CGRect::new(CGPoint::new(0., 0.), CGSize::new(1000., 900.))],
+            spaces: vec![Some(space)],
+            scale_factors: vec![2.0],
+            converter: CoordinateConverter::default(),
+            on_screen: Default::default(),
+        });
+        assert!(raise_manager_rx.try_recv().is_ok());
+    }
+
+    #[test]
+    fn it_surfaces_on_screen_change_when_the_snapshot_omits_the_windows() {
+        let mut apps = Apps::new();
+        let mut reactor = Reactor::new_for_test(LayoutManager::new());
+        let (raise_manager_tx, mut raise_manager_rx) = mpsc::unbounded_channel();
+        reactor.raise_manager_tx = raise_manager_tx;
+        let space = SpaceId::new(1);
+        reactor.handle_event(Event::ScreenParametersChanged {
+            frames: vec![CGRect::new(CGPoint::new(0., 0.), CGSize::new(1000., 1000.))],
+            spaces: vec![Some(space)],
+            scale_factors: vec![2.0],
+            converter: CoordinateConverter::default(),
+            on_screen: Default::default(),
+        });
+        reactor.handle_events(apps.make_app_with_opts(1, make_windows(2), None, false));
+        let _events = apps.simulate_events();
+        while raise_manager_rx.try_recv().is_ok() {}
+
+        // The snapshot lists only a window we don't manage, so it says nothing
+        // about where the windows we want to raise are.
+        let on_screen = vec![WindowServerInfo {
+            id: WindowServerId::new(999),
+            pid: 2,
+            layer: 0,
+            frame: CGRect::new(CGPoint::new(0., 0.), CGSize::new(100., 100.)),
+        }];
+        reactor.handle_event(Event::ScreenParametersChanged {
+            frames: vec![CGRect::new(CGPoint::new(0., 0.), CGSize::new(1000., 900.))],
+            spaces: vec![Some(space)],
+            scale_factors: vec![2.0],
+            converter: CoordinateConverter::default(),
+            on_screen: WindowsOnScreen::new(on_screen),
+        });
+        assert!(raise_manager_rx.try_recv().is_ok());
     }
 
     #[test]

--- a/src/actor/reactor/main_window.rs
+++ b/src/actor/reactor/main_window.rs
@@ -156,6 +156,7 @@ mod tests {
 
             converter: CoordinateConverter::default(),
             scale_factors: vec![2.0],
+            on_screen: Default::default(),
         });
         assert_eq!(None, reactor.main_window());
 
@@ -218,6 +219,7 @@ mod tests {
 
             converter: CoordinateConverter::default(),
             scale_factors: vec![2.0],
+            on_screen: Default::default(),
         });
 
         reactor.handle_event(ApplicationGloballyActivated(1));
@@ -283,6 +285,7 @@ mod tests {
 
             converter: CoordinateConverter::default(),
             scale_factors: vec![2.0],
+            on_screen: Default::default(),
         });
 
         reactor.handle_events(apps.make_app_with_opts(

--- a/src/actor/reactor/restore_snapshots.rs
+++ b/src/actor/reactor/restore_snapshots.rs
@@ -41,6 +41,7 @@ fn canonical_serialized() -> String {
         spaces: vec![Some(SpaceId::new(1))],
         scale_factors: vec![2.0],
         converter: CoordinateConverter::default(),
+        on_screen: Default::default(),
     });
     reactor.handle_events(apps.make_app(1, make_windows(3)));
     reactor.handle_events(apps.make_app(2, make_windows(2)));

--- a/src/actor/space_manager.rs
+++ b/src/actor/space_manager.rs
@@ -133,9 +133,8 @@ impl SpaceManager {
                     spaces: self.active_spaces(),
                     converter,
                     scale_factors,
+                    on_screen,
                 });
-                self.reactor_tx
-                    .send(reactor::Event::WindowsOnScreenUpdated { pid: None, on_screen });
                 self.status_tx.send(status::Event::SpaceChanged(spaces));
                 self.send_space_enabled_status();
                 self.mouse_tx.send(mouse::Request::ScreenParametersChanged(frames, converter));

--- a/src/actor/window_server.rs
+++ b/src/actor/window_server.rs
@@ -14,7 +14,7 @@ use crate::actor::app::{self, AppInfo, AppThreadHandle, Quiet, WindowId, WindowI
 use crate::actor::{self, reactor, space_manager, wm_controller};
 use crate::collections::HashMap;
 use crate::sys::event::MouseState;
-use crate::sys::screen::{NSScreenInfo, ScreenCache};
+use crate::sys::screen::{NSScreenInfo, ScreenCache, ScreenInfo, SpaceId};
 use crate::sys::window_server::{
     self as sys_ws, SkylightConnection, SkylightNotifier, WindowServerId, WindowsOnScreen,
     kCGSWindowIsTerminated,
@@ -41,6 +41,8 @@ pub struct WindowServer {
     skylight_tx: SkylightSender,
     screen_config_retry_attempt: u8,
     screen_config_retry_pending: bool,
+    /// The screen configuration last sent downstream.
+    last_screen_config: Option<(Vec<ScreenInfo>, Vec<Option<SpaceId>>)>,
 }
 
 #[derive(Debug)]
@@ -103,6 +105,7 @@ impl WindowServer {
             skylight_tx,
             screen_config_retry_attempt: 0,
             screen_config_retry_pending: false,
+            last_screen_config: None,
         }
     }
 
@@ -181,12 +184,24 @@ impl WindowServer {
         };
         self.screen_config_retry_attempt = 0;
         self.screen_config_retry_pending = false;
+
+        // The system has been observed to send long runs of this notification
+        // with no actual change; drop them here so the rest of the system never
+        // sees them.
+        let config = (screens, self.screen_cache.get_screen_spaces());
+        if self.last_screen_config.as_ref() == Some(&config) {
+            debug!("Screen configuration is unchanged");
+            return;
+        }
+        self.last_screen_config = Some(config.clone());
+        let (screens, spaces) = config;
+
         let on_screen = self.get_windows_on_screen();
         self.sm_tx.send(space_manager::Event::ScreenParametersChanged {
             screens: screens.iter().map(|s| s.id).collect(),
             frames: screens.iter().map(|s| s.visible_frame).collect(),
             converter,
-            spaces: self.screen_cache.get_screen_spaces(),
+            spaces,
             scale_factors: screens.iter().map(|s| s.scale_factor).collect(),
             on_screen,
         });

--- a/src/actor/window_server.rs
+++ b/src/actor/window_server.rs
@@ -219,6 +219,10 @@ impl WindowServer {
         let attempt = self.screen_config_retry_attempt;
         let Some(&delay) = RETRY_DELAYS.get(attempt as usize) else {
             warn!(attempt, "Giving up on inconsistent screen configuration");
+            // Start over, so that the next inconsistent update gets its own
+            // retries. Otherwise the counter stays exhausted until some later
+            // update happens to succeed.
+            self.screen_config_retry_attempt = 0;
             return;
         };
         self.screen_config_retry_pending = true;
@@ -449,6 +453,19 @@ mod tests {
                 _ => None,
             })
             .collect()
+    }
+
+    #[test]
+    fn giving_up_on_screen_config_resets_the_retry_counter() {
+        let mut h = TestHarness::new();
+        // Pretend the retries for one inconsistent update are exhausted. This
+        // takes the give-up branch, so no retry is scheduled.
+        h.ws.screen_config_retry_attempt = 3;
+        h.ws.schedule_screen_config_retry();
+        assert!(!h.ws.screen_config_retry_pending);
+        // The next inconsistent update should get its own retries rather than
+        // giving up immediately.
+        assert_eq!(h.ws.screen_config_retry_attempt, 0);
     }
 
     #[test]

--- a/src/sys/screen.rs
+++ b/src/sys/screen.rs
@@ -237,7 +237,7 @@ impl System for Actual {
 
 type CGDirectDisplayID = u32;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct ScreenInfo {
     pub visible_frame: CGRect,
     pub id: ScreenId,

--- a/src/sys/window_server.rs
+++ b/src/sys/window_server.rs
@@ -75,7 +75,7 @@ pub struct WindowServerInfo {
 }
 
 /// A snapshot of windows currently visible on screen from the window server.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct WindowsOnScreen {
     pub visible: Vec<WindowServerId>,
     pub info: Vec<WindowServerInfo>,


### PR DESCRIPTION
Fixes endless focus flickering after resizing a Chrome window to be fullscreen with alt+f, from a user report with logs.

macOS delivered 314 `NSApplicationDidChangeScreenParametersNotification`s with
identical payloads in two short bursts. Glide turned each one into a full restack
of every window and queued them all, then spent 50 seconds draining the backlog,
activating every app in turn as it went.

No idea why this happened, but it did happen twice in a short period of time, both after alt-f on a specific Chrome window. These commits prevent the issue "in depth" by removing redundant events/actions at the WindowServer, the Reactor, and RaiseManager.

One commit fixes an unrelated issue in the WindowServer retry logic.

Note that traces recorded before this won't replay: `ScreenParametersChanged`
gained an `on_screen` field, replacing the separate `WindowsOnScreenUpdated` that
followed it.