### PR TITLE
Fix oscillations on interactive resize

### DIFF
--- a/src/actor/layout.rs
+++ b/src/actor/layout.rs
@@ -6,6 +6,7 @@
 use std::fs::{self, File};
 use std::io::{Read, Write};
 use std::path::PathBuf;
+use std::sync::Arc;
 use std::time::Instant;
 
 use objc2_core_foundation::{CGPoint, CGRect, CGSize};
@@ -249,6 +250,8 @@ pub struct LayoutManager {
     interactive_resize: Option<InteractiveScrollResize>,
     #[serde(skip)]
     interactive_move: Option<InteractiveScrollMove>,
+    #[serde(skip, default = "default_config")]
+    config: Arc<Config>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -346,8 +349,12 @@ fn classify_window(rules: &[WindowRule], info: &LayoutWindowInfo) -> WindowClass
     }
 }
 
+fn default_config() -> Arc<Config> {
+    Arc::new(Config::default())
+}
+
 impl LayoutManager {
-    pub fn new() -> Self {
+    pub fn new(config: Arc<Config>) -> Self {
         LayoutManager {
             tree: LayoutTree::new(),
             layout_mapping: Default::default(),
@@ -363,11 +370,13 @@ impl LayoutManager {
             window_rules: Vec::new(),
             interactive_resize: None,
             interactive_move: None,
+            config,
         }
     }
 
-    pub fn set_config(&mut self, config: &Config) {
-        // TODO: store a reference to Config instead of cloning fields
+    pub fn set_config(&mut self, config: &Arc<Config>) {
+        // TODO: read these through self.config instead of cloning them out
+        self.config = config.clone();
         self.scroll_cfg = config.settings.experimental.scroll.clone().validated();
         self.scroll_enabled = self.scroll_cfg.enable;
         self.window_rules = config.window_rules.clone();
@@ -704,7 +713,13 @@ impl LayoutManager {
                     } else {
                         // n.b.: old_frame should reflect the current size in
                         // the layout tree so it can be accurately updated.
-                        self.tree.set_frame_from_resize(node, old_frame, new_frame, screen);
+                        self.tree.set_frame_from_resize(
+                            node,
+                            old_frame,
+                            new_frame,
+                            screen,
+                            &self.config,
+                        );
                     }
                 }
             }
@@ -1557,10 +1572,14 @@ impl LayoutManager {
         self.tree.visible_windows_under(self.tree.root(layout))
     }
 
-    pub fn load(path: PathBuf) -> anyhow::Result<Self> {
+    pub fn load(path: PathBuf, config: Arc<Config>) -> anyhow::Result<Self> {
         let mut buf = String::new();
         File::open(path)?.read_to_string(&mut buf)?;
-        Ok(ron::from_str(&buf)?)
+        let mut manager: Self = ron::from_str(&buf)?;
+        // Only the field, not `set_config`: the caller applies the config, and
+        // `set_config` also converts layouts the config no longer allows.
+        manager.config = config;
+        Ok(manager)
     }
 
     pub fn save(&self, path: PathBuf) -> std::io::Result<()> {
@@ -1658,6 +1677,13 @@ fn detect_edges(point: CGPoint, frame: CGRect) -> ResizeEdge {
 }
 
 #[cfg(test)]
+impl LayoutManager {
+    pub(crate) fn new_for_test() -> Self {
+        Self::new(default_config())
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use objc2_core_foundation::CGPoint;
     use pretty_assertions::assert_eq;
@@ -1688,11 +1714,11 @@ mod tests {
         }
     }
 
-    fn config_with_scroll(enable: bool, default_layout_kind: LayoutKind) -> Config {
+    fn config_with_scroll(enable: bool, default_layout_kind: LayoutKind) -> Arc<Config> {
         let mut config = Config::default();
         config.settings.experimental.scroll.enable = enable;
         config.settings.default_layout_kind = default_layout_kind;
-        config
+        Arc::new(config)
     }
 
     #[test]
@@ -1869,7 +1895,7 @@ mod tests {
     fn it_maintains_separate_layouts_for_each_screen_size() {
         use LayoutCommand::*;
         use LayoutEvent::*;
-        let mut mgr = LayoutManager::new();
+        let mut mgr = LayoutManager::new_for_test();
         let space = SpaceId::new(1);
         let pid = 1;
         let windows = make_windows(pid, 3);
@@ -1943,7 +1969,7 @@ mod tests {
     fn it_culls_unmodified_layouts() {
         use LayoutCommand::*;
         use LayoutEvent::*;
-        let mut mgr = LayoutManager::new();
+        let mut mgr = LayoutManager::new_for_test();
         let space = SpaceId::new(1);
         let pid = 1;
         let windows = make_windows(pid, 3);
@@ -2062,7 +2088,7 @@ mod tests {
     fn floating_windows() {
         use LayoutCommand::*;
         use LayoutEvent::*;
-        let mut mgr = LayoutManager::new();
+        let mut mgr = LayoutManager::new_for_test();
         let space = SpaceId::new(1);
         let pid = 1;
         let config = &Config::default();
@@ -2119,7 +2145,7 @@ mod tests {
     fn floating_windows_space_disabled() {
         use LayoutCommand::*;
         use LayoutEvent::*;
-        let mut mgr = LayoutManager::new();
+        let mut mgr = LayoutManager::new_for_test();
         let space = SpaceId::new(1);
         let pid = 1;
         let config = &Config::default();
@@ -2169,7 +2195,7 @@ mod tests {
     fn space_exposed_does_not_bury_focused_floating_window() {
         use LayoutCommand::*;
         use LayoutEvent::*;
-        let mut mgr = LayoutManager::new();
+        let mut mgr = LayoutManager::new_for_test();
         let space = SpaceId::new(1);
         let pid = 1;
 
@@ -2197,7 +2223,7 @@ mod tests {
     fn it_adds_new_windows_behind_selection() {
         use LayoutCommand::*;
         use LayoutEvent::*;
-        let mut mgr = LayoutManager::new();
+        let mut mgr = LayoutManager::new_for_test();
         let space = SpaceId::new(1);
         let pid = 1;
         let windows = make_windows(pid, 5);
@@ -2303,7 +2329,7 @@ mod tests {
     #[test]
     fn add_remove_add() {
         use LayoutEvent::*;
-        let mut mgr = LayoutManager::new();
+        let mut mgr = LayoutManager::new_for_test();
         let space = SpaceId::new(1);
         let pid = 1;
 
@@ -2343,7 +2369,7 @@ mod tests {
     #[test]
     fn resize_to_full_screen_and_back_preserves_layout() {
         use LayoutEvent::*;
-        let mut mgr = LayoutManager::new();
+        let mut mgr = LayoutManager::new_for_test();
         let space = SpaceId::new(1);
         let pid = 1;
 
@@ -2402,7 +2428,7 @@ mod tests {
     #[test]
     fn resize_to_system_full_screen_and_back_preserves_layout() {
         use LayoutEvent::*;
-        let mut mgr = LayoutManager::new();
+        let mut mgr = LayoutManager::new_for_test();
         let space = SpaceId::new(1);
         let pid = 1;
 
@@ -2446,7 +2472,7 @@ mod tests {
     fn flip_between_screens() {
         use LayoutCommand::*;
         use LayoutEvent::*;
-        let mut mgr = LayoutManager::new();
+        let mut mgr = LayoutManager::new_for_test();
         let space1 = SpaceId::new(1);
         let space2 = SpaceId::new(2);
         let pid = 1;
@@ -2524,7 +2550,7 @@ mod tests {
     fn move_node_between_spaces_keeps_window_mapping_consistent() {
         use LayoutCommand::*;
         use LayoutEvent::*;
-        let mut mgr = LayoutManager::new();
+        let mut mgr = LayoutManager::new_for_test();
         let space1 = SpaceId::new(1);
         let space2 = SpaceId::new(2);
         let pid = 1;
@@ -2579,7 +2605,7 @@ mod tests {
     fn floating_window_space_change_stays_floating() {
         use LayoutCommand::*;
         use LayoutEvent::*;
-        let mut mgr = LayoutManager::new();
+        let mut mgr = LayoutManager::new_for_test();
         let space1 = SpaceId::new(1);
         let space2 = SpaceId::new(2);
         let pid = 1;
@@ -2622,7 +2648,7 @@ mod tests {
     #[test]
     fn window_dragged_into_scroll_space_joins_a_column() {
         use LayoutEvent::*;
-        let mut mgr = LayoutManager::new();
+        let mut mgr = LayoutManager::new_for_test();
         mgr.set_config(&config_with_scroll(true, LayoutKind::Scroll));
         let space1 = SpaceId::new(1);
         let space2 = SpaceId::new(2);
@@ -2660,7 +2686,7 @@ mod tests {
     fn focus_next_prev() {
         use LayoutCommand::*;
         use LayoutEvent::*;
-        let mut mgr = LayoutManager::new();
+        let mut mgr = LayoutManager::new_for_test();
         let space = SpaceId::new(1);
         let pid = 1;
 
@@ -2707,7 +2733,7 @@ mod tests {
     fn it_resizes_windows_with_resize_command() {
         use LayoutCommand::*;
         use LayoutEvent::*;
-        let mut mgr = LayoutManager::new();
+        let mut mgr = LayoutManager::new_for_test();
         let space = SpaceId::new(1);
         let pid = 1;
         let windows = make_windows(pid, 2);
@@ -2762,7 +2788,7 @@ mod tests {
     #[test]
     fn space_exposed_forces_tree_when_scroll_gate_disabled() {
         use LayoutEvent::*;
-        let mut mgr = LayoutManager::new();
+        let mut mgr = LayoutManager::new_for_test();
         let config = config_with_scroll(false, LayoutKind::Scroll);
         mgr.set_config(&config);
 
@@ -2777,7 +2803,7 @@ mod tests {
         use LayoutCommand::*;
         use LayoutEvent::*;
 
-        let mut mgr = LayoutManager::new();
+        let mut mgr = LayoutManager::new_for_test();
         let config = config_with_scroll(false, LayoutKind::Tree);
         mgr.set_config(&config);
 
@@ -2794,7 +2820,7 @@ mod tests {
     fn active_scroll_layout_converts_to_tree_when_gate_disabled() {
         use LayoutEvent::*;
 
-        let mut mgr = LayoutManager::new();
+        let mut mgr = LayoutManager::new_for_test();
         let config_on = config_with_scroll(true, LayoutKind::Scroll);
         mgr.set_config(&config_on);
 
@@ -2815,7 +2841,7 @@ mod tests {
         use LayoutCommand::*;
         use LayoutEvent::*;
 
-        let mut mgr = LayoutManager::new();
+        let mut mgr = LayoutManager::new_for_test();
         let config_on = config_with_scroll(true, LayoutKind::Scroll);
         mgr.set_config(&config_on);
 
@@ -2839,7 +2865,7 @@ mod tests {
     fn scroll_wheel_is_ignored_when_scroll_gate_disabled() {
         use LayoutEvent::*;
 
-        let mut mgr = LayoutManager::new();
+        let mut mgr = LayoutManager::new_for_test();
         let config_on = config_with_scroll(true, LayoutKind::Scroll);
         mgr.set_config(&config_on);
 
@@ -2864,7 +2890,7 @@ mod tests {
         use LayoutCommand::*;
         use LayoutEvent::*;
 
-        let mut mgr = LayoutManager::new();
+        let mut mgr = LayoutManager::new_for_test();
         let config_on = config_with_scroll(true, LayoutKind::Scroll);
         mgr.set_config(&config_on);
 

--- a/src/actor/reactor.rs
+++ b/src/actor/reactor.rs
@@ -222,6 +222,11 @@ pub struct Reactor {
     active_screen_idx: Option<u16>,
     main_window_tracker: MainWindowTracker,
     in_drag: bool,
+    /// The window the user is currently resizing with the mouse, if any.
+    ///
+    /// We don't write frames to this window until the resize ends, since a
+    /// write mid-drag fights the user's mouse.
+    resizing_window: Option<WindowId>,
     record: Record,
     raise_manager_tx: raise::Sender,
     animation_tx: Option<animation::Sender>,
@@ -376,6 +381,7 @@ impl Reactor {
             active_screen_idx: None,
             main_window_tracker: MainWindowTracker::default(),
             in_drag: false,
+            resizing_window: None,
             record,
             raise_manager_tx,
             animation_tx: None,
@@ -524,6 +530,7 @@ impl Reactor {
             Event::WindowDestroyed(wid) => {
                 self.layout.cancel_interactive_state();
                 self.in_drag = false;
+                self.resizing_window = None;
                 if self.windows.remove(&wid).is_none() {
                     warn!("Got destroyed event for unknown window {wid:?}");
                 }
@@ -531,6 +538,11 @@ impl Reactor {
                 self.send_layout_event(LayoutEvent::WindowRemoved(wid));
             }
             Event::WindowFrameChanged(wid, new_frame, last_seen, requested, mouse_state) => {
+                if mouse_state == Some(MouseState::Up) {
+                    // The button is up, so any resize we were holding off on is
+                    // over, even if we never saw the MouseUp event.
+                    self.resizing_window = None;
+                }
                 let window = self.windows.get_mut(&wid).unwrap();
                 if last_seen != window.last_sent_txid {
                     // Ignore events that happened before the last time we
@@ -575,6 +587,9 @@ impl Reactor {
                         new_frame,
                         screens,
                     });
+                    if mouse_state == Some(MouseState::Down) {
+                        self.resizing_window = Some(wid);
+                    }
                     is_resize = true;
                 } else if mouse_state == Some(MouseState::Down) {
                     self.in_drag = true;
@@ -640,6 +655,7 @@ impl Reactor {
                 }
                 self.layout.cancel_interactive_state();
                 self.in_drag = false;
+                self.resizing_window = None;
                 info!("space changed");
                 for (space, screen) in spaces.iter().zip(&mut self.screens) {
                     screen.space = *space;
@@ -713,6 +729,7 @@ impl Reactor {
                     }
                 }
                 self.in_drag = false;
+                self.resizing_window = None;
                 // Now re-check the layout.
             }
             Event::MouseMovedOverWindow(wsid) => {
@@ -1130,6 +1147,13 @@ impl Reactor {
             targets.insert(wid, (frame, scale_factor));
         }
         for (wid, (target_frame, scale_factor)) in targets {
+            if self.resizing_window == Some(wid) {
+                // The user is dragging this window's edge; correct it on mouse
+                // up instead.
+                // TODO: A pending frame override for this window is dropped
+                // here rather than deferred to mouse up.
+                continue;
+            }
             let Some(window) = self.windows.get_mut(&wid) else {
                 // If we restored a saved state the window may not be available yet.
                 continue;
@@ -2140,6 +2164,150 @@ pub mod tests {
             apps.requests().is_empty(),
             "reactor shouldn't move windows mid-drag"
         );
+    }
+
+    /// Neighbors still follow along, and the window is corrected on mouse up.
+    #[test]
+    fn it_doesnt_write_to_a_window_the_user_is_resizing() {
+        let mut apps = Apps::new();
+        let mut reactor = Reactor::new_for_test(LayoutManager::new_for_test());
+        let space = SpaceId::new(1);
+        let screen = CGRect::new(CGPoint::new(0., 0.), CGSize::new(1000., 1000.));
+        reactor.handle_event(Event::ScreenParametersChanged {
+            frames: vec![screen],
+            spaces: vec![Some(space)],
+            scale_factors: vec![2.0],
+            converter: CoordinateConverter::default(),
+            on_screen: Default::default(),
+        });
+        reactor.handle_events(apps.make_app(1, make_windows(2)));
+        reactor.handle_event(Event::StartupComplete);
+        apps.simulate_until_quiet(&mut reactor);
+
+        let resized = WindowId::new(1, 1);
+        let neighbor = WindowId::new(1, 2);
+        let frame = apps.windows[&resized].frame;
+
+        // The user drags the shared edge left, shrinking window 1.
+        let new_frame = CGRect::new(
+            frame.origin,
+            CGSize::new(frame.size.width - 100., frame.size.height),
+        );
+        apps.windows.get_mut(&resized).unwrap().frame = new_frame;
+        reactor.handle_event(Event::WindowFrameChanged(
+            resized,
+            new_frame,
+            apps.windows[&resized].last_seen_txid,
+            Requested(false),
+            Some(MouseState::Down),
+        ));
+
+        // The neighbor grows to fill the space, but we leave the dragged window
+        // alone.
+        let wids = written_wids(apps.requests());
+        assert!(wids.contains(&neighbor), "neighbor should follow: {wids:?}");
+        assert!(
+            !wids.contains(&resized),
+            "shouldn't write to the window being resized: {wids:?}"
+        );
+
+        // The app settles on a change in three directions at once, which the
+        // layout tree refuses to apply. The model and the window now disagree.
+        let odd_frame = CGRect::new(
+            CGPoint::new(new_frame.origin.x + 10., new_frame.origin.y + 10.),
+            CGSize::new(new_frame.size.width - 30., new_frame.size.height - 5.),
+        );
+        apps.windows.get_mut(&resized).unwrap().frame = odd_frame;
+        reactor.handle_event(Event::WindowFrameChanged(
+            resized,
+            odd_frame,
+            apps.windows[&resized].last_seen_txid,
+            Requested(false),
+            Some(MouseState::Down),
+        ));
+        let wids = written_wids(apps.requests());
+        assert!(
+            !wids.contains(&resized),
+            "shouldn't write to the window being resized: {wids:?}"
+        );
+
+        // Releasing the mouse snaps it back to the layout's frame.
+        reactor.handle_event(Event::MouseUp);
+        let wids = written_wids(apps.requests());
+        assert!(
+            wids.contains(&resized),
+            "release should correct the window: {wids:?}"
+        );
+    }
+
+    /// The MouseUp event can be lost, e.g. if the event tap is disabled while
+    /// the button is down. The mouse state on the next frame change releases
+    /// the window instead.
+    #[test]
+    fn it_stops_suppressing_a_resize_when_the_mouse_up_is_missed() {
+        let mut apps = Apps::new();
+        let mut reactor = Reactor::new_for_test(LayoutManager::new_for_test());
+        let space = SpaceId::new(1);
+        let screen = CGRect::new(CGPoint::new(0., 0.), CGSize::new(1000., 1000.));
+        reactor.handle_event(Event::ScreenParametersChanged {
+            frames: vec![screen],
+            spaces: vec![Some(space)],
+            scale_factors: vec![2.0],
+            converter: CoordinateConverter::default(),
+            on_screen: Default::default(),
+        });
+        reactor.handle_events(apps.make_app(1, make_windows(2)));
+        reactor.handle_event(Event::StartupComplete);
+        apps.simulate_until_quiet(&mut reactor);
+
+        let resized = WindowId::new(1, 1);
+        let frame = apps.windows[&resized].frame;
+        let new_frame = CGRect::new(
+            frame.origin,
+            CGSize::new(frame.size.width - 100., frame.size.height),
+        );
+        apps.windows.get_mut(&resized).unwrap().frame = new_frame;
+        reactor.handle_event(Event::WindowFrameChanged(
+            resized,
+            new_frame,
+            apps.windows[&resized].last_seen_txid,
+            Requested(false),
+            Some(MouseState::Down),
+        ));
+        let wids = written_wids(apps.requests());
+        assert!(!wids.contains(&resized), "should be suppressed: {wids:?}");
+
+        // No MouseUp arrives, but the next frame change reports the button up
+        // and asks for a change the tree can't apply, so the model and the
+        // window disagree.
+        let odd_frame = CGRect::new(
+            CGPoint::new(new_frame.origin.x + 10., new_frame.origin.y + 10.),
+            CGSize::new(new_frame.size.width - 30., new_frame.size.height - 5.),
+        );
+        apps.windows.get_mut(&resized).unwrap().frame = odd_frame;
+        reactor.handle_event(Event::WindowFrameChanged(
+            resized,
+            odd_frame,
+            apps.windows[&resized].last_seen_txid,
+            Requested(false),
+            Some(MouseState::Up),
+        ));
+        let wids = written_wids(apps.requests());
+        assert!(
+            wids.contains(&resized),
+            "button up should release the window: {wids:?}"
+        );
+    }
+
+    fn written_wids(requests: Vec<Request>) -> Vec<WindowId> {
+        requests
+            .into_iter()
+            .flat_map(|request| match request {
+                Request::SetWindowFrame(wid, _, _) => vec![wid],
+                Request::AnimationFrame { wid, .. } => vec![wid],
+                _ => vec![],
+            })
+            .collect()
     }
 
     #[test]

--- a/src/actor/reactor.rs
+++ b/src/actor/reactor.rs
@@ -1189,7 +1189,7 @@ pub mod tests {
     #[test]
     fn it_ignores_stale_resize_events() {
         let mut apps = Apps::new();
-        let mut reactor = Reactor::new_for_test(LayoutManager::new());
+        let mut reactor = Reactor::new_for_test(LayoutManager::new_for_test());
         reactor.handle_event(Event::ScreenParametersChanged {
             frames: vec![CGRect::new(CGPoint::new(0., 0.), CGSize::new(1000., 1000.))],
             spaces: vec![Some(SpaceId::new(1))],
@@ -1221,7 +1221,7 @@ pub mod tests {
     fn it_sends_layout_animation_to_manager() {
         let mut apps = Apps::new();
         let (mut reactor, mut animation_rx) =
-            Reactor::new_for_test_with_animation(LayoutManager::new(), true);
+            Reactor::new_for_test_with_animation(LayoutManager::new_for_test(), true);
         reactor.handle_event(Event::ScreenParametersChanged {
             frames: vec![CGRect::new(CGPoint::new(0., 0.), CGSize::new(1000., 1000.))],
             spaces: vec![Some(SpaceId::new(1))],
@@ -1248,7 +1248,7 @@ pub mod tests {
         use LayoutCommand::ToggleWindowFloating;
 
         let mut apps = Apps::new();
-        let mut reactor = Reactor::new_for_test(LayoutManager::new());
+        let mut reactor = Reactor::new_for_test(LayoutManager::new_for_test());
         let space = SpaceId::new(1);
         let screen = CGRect::new(CGPoint::new(0., 0.), CGSize::new(1000., 1000.));
         let wid = WindowId::new(1, 1);
@@ -1304,7 +1304,7 @@ pub mod tests {
 
         let mut apps = Apps::new();
         let (mut reactor, mut animation_rx) =
-            Reactor::new_for_test_with_animation(LayoutManager::new(), true);
+            Reactor::new_for_test_with_animation(LayoutManager::new_for_test(), true);
         let space = SpaceId::new(1);
         let screen = CGRect::new(CGPoint::new(0., 0.), CGSize::new(1000., 1000.));
         let wid = WindowId::new(1, 1);
@@ -1339,7 +1339,7 @@ pub mod tests {
     #[test]
     fn it_sends_writes_when_stale_read_state_looks_same_as_written_state() {
         let mut apps = Apps::new();
-        let mut reactor = Reactor::new_for_test(LayoutManager::new());
+        let mut reactor = Reactor::new_for_test(LayoutManager::new_for_test());
         reactor.handle_event(Event::ScreenParametersChanged {
             frames: vec![CGRect::new(CGPoint::new(0., 0.), CGSize::new(1000., 1000.))],
             spaces: vec![Some(SpaceId::new(1))],
@@ -1378,7 +1378,7 @@ pub mod tests {
     #[test]
     fn sends_writes_same_as_last_written_state_if_changed_externally() {
         let mut apps = Apps::new();
-        let mut reactor = Reactor::new_for_test(LayoutManager::new());
+        let mut reactor = Reactor::new_for_test(LayoutManager::new_for_test());
         reactor.handle_event(Event::ScreenParametersChanged {
             frames: vec![CGRect::new(CGPoint::new(0., 0.), CGSize::new(1000., 1000.))],
             spaces: vec![Some(SpaceId::new(1))],
@@ -1421,7 +1421,7 @@ pub mod tests {
     #[test]
     fn it_responds_to_resizes() {
         let mut apps = Apps::new();
-        let mut reactor = Reactor::new_for_test(LayoutManager::new());
+        let mut reactor = Reactor::new_for_test(LayoutManager::new_for_test());
         reactor.handle_event(Event::ScreenParametersChanged {
             frames: vec![CGRect::new(CGPoint::new(0., 0.), CGSize::new(1000., 1000.))],
             spaces: vec![Some(SpaceId::new(1))],
@@ -1470,7 +1470,7 @@ pub mod tests {
     #[test]
     fn it_manages_windows_on_enabled_spaces() {
         let mut apps = Apps::new();
-        let mut reactor = Reactor::new_for_test(LayoutManager::new());
+        let mut reactor = Reactor::new_for_test(LayoutManager::new_for_test());
         let full_screen = CGRect::new(CGPoint::new(0., 0.), CGSize::new(1000., 1000.));
         reactor.handle_event(Event::ScreenParametersChanged {
             frames: vec![full_screen],
@@ -1493,7 +1493,7 @@ pub mod tests {
     #[test]
     fn it_selects_the_main_window_on_space_enable() {
         let mut apps = Apps::new();
-        let mut reactor = Reactor::new_for_test(LayoutManager::new());
+        let mut reactor = Reactor::new_for_test(LayoutManager::new_for_test());
         let full_screen = CGRect::new(CGPoint::new(0., 0.), CGSize::new(1000., 1000.));
         let ws_info = (1..=2)
             .map(|id| WindowServerInfo {
@@ -1539,7 +1539,7 @@ pub mod tests {
     #[test]
     fn it_surfaces_on_screen_change_when_the_snapshot_is_empty() {
         let mut apps = Apps::new();
-        let mut reactor = Reactor::new_for_test(LayoutManager::new());
+        let mut reactor = Reactor::new_for_test(LayoutManager::new_for_test());
         let (raise_manager_tx, mut raise_manager_rx) = mpsc::unbounded_channel();
         reactor.raise_manager_tx = raise_manager_tx;
         let space = SpaceId::new(1);
@@ -1567,7 +1567,7 @@ pub mod tests {
     #[test]
     fn it_surfaces_on_screen_change_when_the_snapshot_omits_the_windows() {
         let mut apps = Apps::new();
-        let mut reactor = Reactor::new_for_test(LayoutManager::new());
+        let mut reactor = Reactor::new_for_test(LayoutManager::new_for_test());
         let (raise_manager_tx, mut raise_manager_rx) = mpsc::unbounded_channel();
         reactor.raise_manager_tx = raise_manager_tx;
         let space = SpaceId::new(1);
@@ -1603,7 +1603,7 @@ pub mod tests {
     #[test]
     fn it_skips_surface_on_screen_change_when_top_layer_order_matches() {
         let mut apps = Apps::new();
-        let mut reactor = Reactor::new_for_test(LayoutManager::new());
+        let mut reactor = Reactor::new_for_test(LayoutManager::new_for_test());
         let (raise_manager_tx, mut raise_manager_rx) = mpsc::unbounded_channel();
         reactor.raise_manager_tx = raise_manager_tx;
         let space = SpaceId::new(1);
@@ -1645,7 +1645,7 @@ pub mod tests {
     #[test]
     fn it_surfaces_on_screen_change_when_another_window_is_in_front() {
         let mut apps = Apps::new();
-        let mut reactor = Reactor::new_for_test(LayoutManager::new());
+        let mut reactor = Reactor::new_for_test(LayoutManager::new_for_test());
         let (raise_manager_tx, mut raise_manager_rx) = mpsc::unbounded_channel();
         reactor.raise_manager_tx = raise_manager_tx;
         let space = SpaceId::new(1);
@@ -1687,7 +1687,7 @@ pub mod tests {
     #[test]
     fn it_skips_surface_when_top_layer_order_matches() {
         let mut apps = Apps::new();
-        let mut reactor = Reactor::new_for_test(LayoutManager::new());
+        let mut reactor = Reactor::new_for_test(LayoutManager::new_for_test());
         let (raise_manager_tx, mut raise_manager_rx) = mpsc::unbounded_channel();
         reactor.raise_manager_tx = raise_manager_tx;
         let space = SpaceId::new(1);
@@ -1726,7 +1726,7 @@ pub mod tests {
     #[test]
     fn it_skips_surface_when_top_layer_windows_are_reordered() {
         let mut apps = Apps::new();
-        let mut reactor = Reactor::new_for_test(LayoutManager::new());
+        let mut reactor = Reactor::new_for_test(LayoutManager::new_for_test());
         let (raise_manager_tx, mut raise_manager_rx) = mpsc::unbounded_channel();
         reactor.raise_manager_tx = raise_manager_tx;
         let space = SpaceId::new(1);
@@ -1766,7 +1766,7 @@ pub mod tests {
     #[test]
     fn it_surfaces_top_layer_windows_when_top_managed_set_differs() {
         let mut apps = Apps::new();
-        let mut reactor = Reactor::new_for_test(LayoutManager::new());
+        let mut reactor = Reactor::new_for_test(LayoutManager::new_for_test());
         let (raise_manager_tx, mut raise_manager_rx) = mpsc::unbounded_channel();
         reactor.raise_manager_tx = raise_manager_tx;
         let space = SpaceId::new(1);
@@ -1818,7 +1818,7 @@ pub mod tests {
 
     #[test]
     fn filter_response_clears_matching_focus_and_raise_windows() {
-        let mut reactor = Reactor::new_for_test(LayoutManager::new());
+        let mut reactor = Reactor::new_for_test(LayoutManager::new_for_test());
         reactor.screens = vec![Screen {
             frame: CGRect::new(CGPoint::new(0., 0.), CGSize::new(1000., 1000.)),
             space: Some(SpaceId::new(1)),
@@ -1888,7 +1888,7 @@ pub mod tests {
 
     #[test]
     fn filter_response_keeps_response_when_focus_is_not_frontmost() {
-        let reactor = Reactor::new_for_test(LayoutManager::new());
+        let reactor = Reactor::new_for_test(LayoutManager::new_for_test());
         let w1 = WindowId::with_wsid(1, WindowServerId::new(1));
         let w2 = WindowId::with_wsid(1, WindowServerId::new(2));
 
@@ -1908,7 +1908,7 @@ pub mod tests {
     #[test]
     fn it_ignores_unmanaged_and_nonzero_layer_windows_when_comparing_space_order() {
         let mut apps = Apps::new();
-        let mut reactor = Reactor::new_for_test(LayoutManager::new());
+        let mut reactor = Reactor::new_for_test(LayoutManager::new_for_test());
         let (raise_manager_tx, mut raise_manager_rx) = mpsc::unbounded_channel();
         reactor.raise_manager_tx = raise_manager_tx;
         let space = SpaceId::new(1);
@@ -1958,7 +1958,7 @@ pub mod tests {
     #[test]
     fn it_ignores_windows_on_disabled_spaces() {
         let mut apps = Apps::new();
-        let mut reactor = Reactor::new_for_test(LayoutManager::new());
+        let mut reactor = Reactor::new_for_test(LayoutManager::new_for_test());
         let full_screen = CGRect::new(CGPoint::new(0., 0.), CGSize::new(1000., 1000.));
         reactor.handle_event(Event::ScreenParametersChanged {
             frames: vec![full_screen],
@@ -1987,7 +1987,7 @@ pub mod tests {
     #[test]
     fn it_keeps_discovered_windows_on_their_initial_screen() {
         let mut apps = Apps::new();
-        let mut reactor = Reactor::new_for_test(LayoutManager::new());
+        let mut reactor = Reactor::new_for_test(LayoutManager::new_for_test());
         let screen1 = CGRect::new(CGPoint::new(0., 0.), CGSize::new(1000., 1000.));
         let screen2 = CGRect::new(CGPoint::new(1000., 0.), CGSize::new(1000., 1000.));
         reactor.handle_event(Event::ScreenParametersChanged {
@@ -2016,7 +2016,7 @@ pub mod tests {
     #[test]
     fn it_moves_windows_dragged_between_spaces() {
         let mut apps = Apps::new();
-        let mut reactor = Reactor::new_for_test(LayoutManager::new());
+        let mut reactor = Reactor::new_for_test(LayoutManager::new_for_test());
         let screen1 = CGRect::new(CGPoint::new(0., 0.), CGSize::new(1000., 1000.));
         let screen2 = CGRect::new(CGPoint::new(1000., 0.), CGSize::new(1000., 1000.));
         let space1 = SpaceId::new(1);
@@ -2093,7 +2093,7 @@ pub mod tests {
     #[test]
     fn it_keeps_windows_in_space_on_intra_space_drag() {
         let mut apps = Apps::new();
-        let mut reactor = Reactor::new_for_test(LayoutManager::new());
+        let mut reactor = Reactor::new_for_test(LayoutManager::new_for_test());
         let screen1 = CGRect::new(CGPoint::new(0., 0.), CGSize::new(1000., 1000.));
         let screen2 = CGRect::new(CGPoint::new(1000., 0.), CGSize::new(1000., 1000.));
         let space1 = SpaceId::new(1);
@@ -2145,7 +2145,7 @@ pub mod tests {
     #[test]
     fn it_ignores_windows_on_nonzero_layers() {
         let mut apps = Apps::new();
-        let mut reactor = Reactor::new_for_test(LayoutManager::new());
+        let mut reactor = Reactor::new_for_test(LayoutManager::new_for_test());
         let full_screen = CGRect::new(CGPoint::new(0., 0.), CGSize::new(1000., 1000.));
         reactor.handle_event(Event::ScreenParametersChanged {
             frames: vec![full_screen],
@@ -2183,7 +2183,7 @@ pub mod tests {
     #[test]
     fn handle_layout_response_groups_windows_by_app_and_screen() {
         let mut apps = Apps::new();
-        let mut reactor = Reactor::new_for_test(LayoutManager::new());
+        let mut reactor = Reactor::new_for_test(LayoutManager::new_for_test());
         let (raise_manager_tx, mut raise_manager_rx) = mpsc::unbounded_channel();
         reactor.raise_manager_tx = raise_manager_tx;
 
@@ -2241,7 +2241,7 @@ pub mod tests {
     #[test]
     fn handle_layout_response_includes_handles_for_raise_and_focus_windows() {
         let mut apps = Apps::new();
-        let mut reactor = Reactor::new_for_test(LayoutManager::new());
+        let mut reactor = Reactor::new_for_test(LayoutManager::new_for_test());
         let (raise_manager_tx, mut raise_manager_rx) = mpsc::unbounded_channel();
         reactor.raise_manager_tx = raise_manager_tx;
 
@@ -2269,7 +2269,7 @@ pub mod tests {
     fn it_preserves_layout_after_login_screen() {
         // TODO: This would be better tested with a more complete simulation.
         let mut apps = Apps::new();
-        let mut reactor = Reactor::new_for_test(LayoutManager::new());
+        let mut reactor = Reactor::new_for_test(LayoutManager::new_for_test());
         let space = SpaceId::new(1);
         let full_screen = CGRect::new(CGPoint::new(0., 0.), CGSize::new(1000., 1000.));
         reactor.handle_event(Event::ScreenParametersChanged {
@@ -2358,7 +2358,7 @@ pub mod tests {
     #[test]
     fn it_fixes_window_sizes_after_screen_config_changes() {
         let mut apps = Apps::new();
-        let mut reactor = Reactor::new_for_test(LayoutManager::new());
+        let mut reactor = Reactor::new_for_test(LayoutManager::new_for_test());
         let full_screen = CGRect::new(CGPoint::new(0., 0.), CGSize::new(1000., 1000.));
         reactor.handle_event(Event::ScreenParametersChanged {
             frames: vec![full_screen],
@@ -2415,7 +2415,7 @@ pub mod tests {
         use super::Command::*;
         use super::Reactor;
         let mut apps = Apps::new();
-        let mut reactor = Reactor::new_for_test(LayoutManager::new());
+        let mut reactor = Reactor::new_for_test(LayoutManager::new_for_test());
         let space = SpaceId::new(1);
         reactor.handle_event(ScreenParametersChanged {
             frames: vec![CGRect::ZERO],
@@ -2448,7 +2448,7 @@ pub mod tests {
         use super::Reactor;
 
         let mut apps = Apps::new();
-        let mut reactor = Reactor::new_for_test(LayoutManager::new());
+        let mut reactor = Reactor::new_for_test(LayoutManager::new_for_test());
         let space = SpaceId::new(1);
         reactor.handle_event(ScreenParametersChanged {
             frames: vec![CGRect::ZERO],
@@ -2492,7 +2492,7 @@ pub mod tests {
         let full_screen = CGRect::new(CGPoint::new(0., 0.), CGSize::new(1000., 1000.));
 
         // First reactor: simulate the state before shutdown with three apps running
-        let mut reactor1 = Reactor::new_for_test(LayoutManager::new());
+        let mut reactor1 = Reactor::new_for_test(LayoutManager::new_for_test());
         reactor1.handle_event(ScreenParametersChanged {
             frames: vec![full_screen],
             spaces: vec![Some(space)],
@@ -2559,7 +2559,7 @@ pub mod tests {
 
     #[test]
     fn no_scroll_animation_when_idle() {
-        let mut reactor = Reactor::new_for_test(LayoutManager::new());
+        let mut reactor = Reactor::new_for_test(LayoutManager::new_for_test());
         let space = SpaceId::new(1);
         let screen = CGRect::new(CGPoint::new(0., 0.), CGSize::new(1000., 1000.));
         reactor.handle_event(Event::ScreenParametersChanged {

--- a/src/actor/reactor/main_window.rs
+++ b/src/actor/reactor/main_window.rs
@@ -148,7 +148,7 @@ mod tests {
     fn it_tracks_frontmost_app_and_main_window_correctly() {
         use Event::*;
         let mut apps = Apps::new();
-        let mut reactor = Reactor::new_for_test(LayoutManager::new());
+        let mut reactor = Reactor::new_for_test(LayoutManager::new_for_test());
         let space = SpaceId::new(1);
         reactor.handle_event(ScreenParametersChanged {
             frames: vec![CGRect::ZERO],
@@ -211,7 +211,7 @@ mod tests {
     fn it_does_not_update_layout_for_quiet_raises() {
         use Event::*;
         let mut apps = Apps::new();
-        let mut reactor = Reactor::new_for_test(LayoutManager::new());
+        let mut reactor = Reactor::new_for_test(LayoutManager::new_for_test());
         let space = SpaceId::new(1);
         reactor.handle_event(ScreenParametersChanged {
             frames: vec![CGRect::ZERO],
@@ -275,7 +275,7 @@ mod tests {
     fn it_selects_main_window_when_space_is_enabled() {
         use Event::*;
         let mut apps = Apps::new();
-        let mut reactor = Reactor::new_for_test(LayoutManager::new());
+        let mut reactor = Reactor::new_for_test(LayoutManager::new_for_test());
         let pid = 3;
         let windows = make_windows(2);
         let space = SpaceId::new(1);

--- a/src/actor/reactor/restore_snapshots.rs
+++ b/src/actor/reactor/restore_snapshots.rs
@@ -35,7 +35,7 @@ fn snapshot_dir() -> PathBuf {
 /// inputs always produce byte-identical output, so a format change is visible.
 fn canonical_serialized() -> String {
     let mut apps = Apps::new();
-    let mut reactor = Reactor::new_for_test(LayoutManager::new());
+    let mut reactor = Reactor::new_for_test(LayoutManager::new_for_test());
     reactor.handle_event(Event::ScreenParametersChanged {
         frames: vec![CGRect::new(CGPoint::new(0., 0.), CGSize::new(1000., 1000.))],
         spaces: vec![Some(SpaceId::new(1))],

--- a/src/bin/glide_server.rs
+++ b/src/bin/glide_server.rs
@@ -109,14 +109,14 @@ fn main() {
     NSApp(mtm).finishLaunching();
 
     if opt.validate {
-        LayoutManager::load(restore_file()).unwrap();
+        LayoutManager::load(restore_file(), config.clone()).unwrap();
         return;
     }
 
     let layout = if opt.restore {
-        LayoutManager::load(restore_file()).unwrap()
+        LayoutManager::load(restore_file(), config.clone()).unwrap()
     } else {
-        LayoutManager::new()
+        LayoutManager::new(config.clone())
     };
     let (mouse_tx, mouse_rx) = channel();
     let (status_tx, status_rx) = channel();

--- a/src/model/layout_tree.rs
+++ b/src/model/layout_tree.rs
@@ -727,8 +727,9 @@ impl LayoutTree {
         self.tree.data.window.swap_windows(node_a, node_b);
     }
 
-    pub fn resize(&mut self, node: NodeId, screen_ratio: f64, direction: Direction) -> bool {
-        // Pick an ancestor to resize that has a sibling in the given direction.
+    /// Picks the ancestor of `node` (possibly `node` itself) to resize, along
+    /// with the sibling it exchanges space with.
+    fn resize_target(&self, node: NodeId, direction: Direction) -> Option<(NodeId, NodeId)> {
         let can_resize = |&node: &NodeId| -> bool {
             let Some(parent) = node.parent(&self.tree.map) else {
                 return false;
@@ -736,10 +737,70 @@ impl LayoutTree {
             !self.tree.data.size.kind(parent).is_group()
                 && self.move_over(node, direction).is_some()
         };
-        let Some(resizing_node) = node.ancestors(&self.tree.map).filter(can_resize).next() else {
+        let resizing_node = node.ancestors(&self.tree.map).filter(can_resize).next()?;
+        let sibling = self.move_over(resizing_node, direction).unwrap();
+        Some((resizing_node, sibling))
+    }
+
+    /// The number of pixels one unit of `parent`'s total weight is worth.
+    ///
+    /// Returns `None` if `parent` is not laid out on `screen`.
+    fn pixels_per_weight(&self, parent: NodeId, screen: CGRect, config: &Config) -> Option<f64> {
+        let root = parent.ancestors(&self.tree.map).last().unwrap();
+        let parent_rect = self.tree.data.size.get_node_rect(
+            &self.tree.map,
+            &self.tree.data.window,
+            &self.tree.data.selection,
+            config,
+            root,
+            screen,
+            self.is_scroll_root(root),
+            parent,
+        )?;
+        Some(self.tree.data.size.pixels_per_weight(
+            &self.tree.map,
+            parent,
+            parent_rect,
+            config,
+            self.is_scroll_root(parent),
+        ))
+    }
+
+    /// Resizes `node` by `delta` pixels along `direction`.
+    ///
+    /// This is not the same as [`Self::resize`] with `delta` as a fraction of
+    /// the screen: gaps take up screen space that is not distributed by weight,
+    /// so a fraction of the screen is worth fewer pixels in the layout.
+    ///
+    /// The resulting frame can still land a pixel away from the requested one,
+    /// since each child's frame is rounded independently and positions follow
+    /// the rounded edge of the previous sibling.
+    pub fn resize_by_pixels(
+        &mut self,
+        node: NodeId,
+        delta: f64,
+        direction: Direction,
+        screen: CGRect,
+        config: &Config,
+    ) -> bool {
+        let Some((resizing_node, sibling)) = self.resize_target(node, direction) else {
             return false;
         };
-        let sibling = self.move_over(resizing_node, direction).unwrap();
+        let parent = resizing_node.parent(&self.tree.map).unwrap();
+        let Some(px_per_weight) = self.pixels_per_weight(parent, screen, config) else {
+            return false;
+        };
+        if px_per_weight <= 0.0 {
+            return false;
+        }
+        self.apply_resize(resizing_node, sibling, parent, delta / px_per_weight);
+        true
+    }
+
+    pub fn resize(&mut self, node: NodeId, screen_ratio: f64, direction: Direction) -> bool {
+        let Some((resizing_node, sibling)) = self.resize_target(node, direction) else {
+            return false;
+        };
 
         // Compute the share of resizing_node's parent that needs to be taken
         // from the sibling.
@@ -757,17 +818,30 @@ impl LayoutTree {
         });
         let parent = resizing_node.parent(&self.tree.map).unwrap();
         let parent_total = self.tree.data.size.total(parent);
-        let is_scroll_column = self.is_scroll_root(parent);
-        let local_ratio = if is_scroll_column {
-            f64::from(screen_ratio) / exchange_rate
+        let local_ratio = if self.is_scroll_root(parent) {
+            screen_ratio / exchange_rate
         } else {
-            f64::from(screen_ratio) * parent_total / exchange_rate
+            screen_ratio * parent_total / exchange_rate
         };
-        if is_scroll_column {
+        self.apply_resize(resizing_node, sibling, parent, local_ratio);
+
+        true
+    }
+
+    /// Moves `delta_weight` units of `parent`'s total weight to
+    /// `resizing_node`, taking it from `sibling`.
+    fn apply_resize(
+        &mut self,
+        resizing_node: NodeId,
+        sibling: NodeId,
+        parent: NodeId,
+        delta_weight: f64,
+    ) {
+        if self.is_scroll_root(parent) {
             let current_weight = self.tree.data.size.weight(resizing_node);
             self.tree.data.size.set_weight(
                 resizing_node,
-                current_weight + local_ratio as f32,
+                current_weight + delta_weight as f32,
                 &self.tree.map,
             );
         } else {
@@ -775,11 +849,9 @@ impl LayoutTree {
                 &self.tree.map,
                 resizing_node,
                 sibling,
-                local_ratio as f32,
+                delta_weight as f32,
             );
         }
-
-        true
     }
 
     /// Call this during a user resize to have the model respond appropriately.
@@ -791,12 +863,13 @@ impl LayoutTree {
         old_frame: CGRect,
         new_frame: CGRect,
         screen: CGRect,
+        config: &Config,
     ) {
         let mut check_or_resize = |resize: bool| {
             let mut count = 0;
             let mut first_direction: Option<Direction> = None;
             let mut good = true;
-            let mut check_and_resize = |direction: Direction, delta, whole| {
+            let mut check_and_resize = |direction: Direction, delta| {
                 if delta != 0.0 {
                     count += 1;
                     if count > 2 {
@@ -810,30 +883,14 @@ impl LayoutTree {
                         first_direction = Some(direction);
                     }
                     if resize {
-                        self.resize(node, f64::from(delta) / f64::from(whole), direction);
+                        self.resize_by_pixels(node, delta, direction, screen, config);
                     }
                 }
             };
-            check_and_resize(
-                Direction::Left,
-                old_frame.min().x - new_frame.min().x,
-                screen.size.width,
-            );
-            check_and_resize(
-                Direction::Right,
-                new_frame.max().x - old_frame.max().x,
-                screen.size.width,
-            );
-            check_and_resize(
-                Direction::Up,
-                old_frame.min().y - new_frame.min().y,
-                screen.size.height,
-            );
-            check_and_resize(
-                Direction::Down,
-                new_frame.max().y - old_frame.max().y,
-                screen.size.height,
-            );
+            check_and_resize(Direction::Left, old_frame.min().x - new_frame.min().x);
+            check_and_resize(Direction::Right, new_frame.max().x - old_frame.max().x);
+            check_and_resize(Direction::Up, old_frame.min().y - new_frame.min().y);
+            check_and_resize(Direction::Down, new_frame.max().y - old_frame.max().y);
             good
         };
         if !check_or_resize(false) {
@@ -1605,10 +1662,17 @@ mod tests {
             rect(1000, 1000, 500, 1000),
             rect(1000, 1100, 500, 1000),
             screen,
+            config,
         );
         assert_frames_are(tree.calculate_layout(layout, screen, config), orig.clone());
 
-        tree.set_frame_from_resize(a1, rect(0, 0, 1000, 3000), rect(0, 0, 1010, 3000), screen);
+        tree.set_frame_from_resize(
+            a1,
+            rect(0, 0, 1000, 3000),
+            rect(0, 0, 1010, 3000),
+            screen,
+            config,
+        );
         assert_frames_are(
             tree.calculate_layout(layout, screen, config),
             [
@@ -1621,7 +1685,13 @@ mod tests {
             ],
         );
 
-        tree.set_frame_from_resize(a1, rect(0, 0, 1010, 3000), rect(0, 0, 1000, 3000), screen);
+        tree.set_frame_from_resize(
+            a1,
+            rect(0, 0, 1010, 3000),
+            rect(0, 0, 1000, 3000),
+            screen,
+            config,
+        );
         assert_frames_are(tree.calculate_layout(layout, screen, config), orig.clone());
 
         tree.set_frame_from_resize(
@@ -1629,6 +1699,7 @@ mod tests {
             rect(1000, 1000, 500, 1000),
             rect(900, 900, 600, 1100),
             screen,
+            config,
         );
         assert_frames_are(
             tree.calculate_layout(layout, screen, config),
@@ -1645,6 +1716,62 @@ mod tests {
                 (WindowId::new(1, 3), rect(2000, 0, 1000, 3000)),
             ],
         );
+    }
+
+    /// A drag moves the edge by as many pixels as the user dragged it, whatever
+    /// the gap settings. Regression test for #227.
+    #[test]
+    fn set_frame_from_resize_tracks_the_user_with_gaps() {
+        for gap in [0.0, 8.0, 40.0] {
+            for &vertical in &[false, true] {
+                let mut tree = LayoutTree::new();
+                let layout = tree.create_layout();
+                let root = tree.root(layout);
+                if vertical {
+                    tree.set_container_kind(root, ContainerKind::Vertical);
+                }
+                let _a = tree.add_window_under(layout, root, WindowId::new(1, 1));
+                let _b = tree.add_window_under(layout, root, WindowId::new(1, 2));
+                let _c = tree.add_window_under(layout, root, WindowId::new(1, 3));
+                let screen = rect(0, 39, 1800, 1130);
+                let mut config = Config::default();
+                config.settings.outer_gap = gap;
+                config.settings.inner_gap = gap;
+                let node = tree.window_node(layout, WindowId::new(1, 2)).unwrap();
+
+                let frame_of = |tree: &LayoutTree, wid| {
+                    tree.calculate_layout(layout, screen, &config)
+                        .into_iter()
+                        .find(|&(w, _)| w == wid)
+                        .unwrap()
+                        .1
+                };
+
+                // Drag the middle window's leading edge in increments, as a
+                // stream of AXWindowResized notifications would report it.
+                let mut cur = frame_of(&tree, WindowId::new(1, 2));
+                for _ in 0..5 {
+                    let new = if vertical {
+                        CGRect::new(
+                            CGPoint::new(cur.origin.x, cur.origin.y + 17.),
+                            CGSize::new(cur.size.width, cur.size.height - 17.),
+                        )
+                    } else {
+                        CGRect::new(
+                            CGPoint::new(cur.origin.x + 34., cur.origin.y),
+                            CGSize::new(cur.size.width - 34., cur.size.height),
+                        )
+                    };
+                    tree.set_frame_from_resize(node, cur, new, screen, &config);
+                    assert_eq!(
+                        frame_of(&tree, WindowId::new(1, 2)),
+                        new,
+                        "gap={gap} vertical={vertical}: layout disagrees with the user's frame"
+                    );
+                    cur = new;
+                }
+            }
+        }
     }
 
     #[test]

--- a/src/model/size.rs
+++ b/src/model/size.rs
@@ -273,9 +273,72 @@ impl Size {
             is_scroll,
             sizes: &mut sizes,
             groups: None,
+            target: None,
+            target_rect: None,
         }
         .visit(root, screen);
         sizes
+    }
+
+    /// Returns the rect the layout assigns to `node`.
+    ///
+    /// `node` must be reachable from `root`.
+    pub(super) fn get_node_rect(
+        &self,
+        map: &NodeMap,
+        window: &super::window::Window,
+        selection: &Selection,
+        config: &Config,
+        root: NodeId,
+        screen: CGRect,
+        is_scroll: bool,
+        node: NodeId,
+    ) -> Option<CGRect> {
+        let mut sizes = vec![];
+        Visitor {
+            map,
+            size: self,
+            window,
+            selection,
+            fullscreen_nodes: &[],
+            config,
+            screen,
+            is_scroll,
+            sizes: &mut sizes,
+            groups: None,
+            target: Some(node),
+            target_rect: None,
+        }
+        .visit(root, screen)
+    }
+
+    /// The extent, along `parent`'s orientation, that one unit of `parent`'s
+    /// total weight is worth in its children's frames.
+    ///
+    /// The inner gaps between children are subtracted first, since they are not
+    /// distributed by weight.
+    pub(super) fn pixels_per_weight(
+        &self,
+        map: &NodeMap,
+        parent: NodeId,
+        parent_rect: CGRect,
+        config: &Config,
+        is_scroll_root: bool,
+    ) -> f64 {
+        let extent = match self.kind(parent).orientation() {
+            Orientation::Horizontal => parent_rect.size.width,
+            Orientation::Vertical => parent_rect.size.height,
+        };
+        let total = self.total(parent);
+        // Mirrors the inputs `Visitor` gives to `solve_sizes`.
+        let available = if is_scroll_root {
+            total * extent
+        } else {
+            extent
+        };
+        let count = parent.children(map).count() as f64;
+        let usable = available - config.settings.inner_gap * (count - 1.0).max(0.0);
+        usable / total
     }
 
     pub(super) fn get_sizes_and_groups(
@@ -305,6 +368,8 @@ impl Size {
             is_scroll,
             sizes: &mut sizes,
             groups: Some(&mut groups),
+            target: None,
+            target_rect: None,
         }
         .visit(root, screen);
         (sizes, groups)
@@ -322,15 +387,19 @@ struct Visitor<'a, 'out> {
     is_scroll: bool,
     sizes: &'out mut Vec<(WindowId, CGRect)>,
     groups: Option<&'out mut Vec<GroupBarInfo>>,
+    /// If set, the rect assigned to this node is recorded in `target_rect`.
+    target: Option<NodeId>,
+    target_rect: Option<CGRect>,
 }
 
 impl<'a, 'out> Visitor<'a, 'out> {
-    fn visit(mut self, root: NodeId, rect: CGRect) {
+    fn visit(mut self, root: NodeId, rect: CGRect) -> Option<CGRect> {
         // Usually this should be false, except in the uncommon case where root
         // is fullscreen.
         let parent_visible = self.fullscreen_nodes.contains(&root);
         let rect = rect.inset(self.config.settings.outer_gap);
         self.visit_node(root, rect, true, parent_visible, true);
+        self.target_rect
     }
 
     fn visit_node(
@@ -347,6 +416,10 @@ impl<'a, 'out> Visitor<'a, 'out> {
         } else {
             rect
         };
+
+        if self.target == Some(node) {
+            self.target_rect = Some(rect);
+        }
 
         if let Some(wid) = self.window.at(node) {
             debug_assert!(


### PR DESCRIPTION
- **fix: Fix oscillation when resizing a window with the mouse**
- **fix: Don't resize a window while the user is dragging its edge**

This fixes two issues with resizing, #176 and #227.