### PR TITLE
Stop Glide's own raises from changing focus and reconcile the layout with the OS state when user raises fail

### DIFF
--- a/src/actor/app.rs
+++ b/src/actor/app.rs
@@ -172,6 +172,10 @@ struct RaiseRequest(Vec<WindowId>, CancellationToken, u64, Quiet);
 /// wait indefinitely.
 const ACTIVATION_TIMEOUT: Duration = Duration::from_millis(1000);
 
+/// How long we keep attributing an activation to a raise after the raise was
+/// cancelled. The activation is already in flight at that point.
+const CANCELLED_ACTIVATION_GRACE: Duration = Duration::from_millis(100);
+
 #[derive(Debug, Copy, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub enum Quiet {
     Yes,
@@ -202,6 +206,8 @@ struct State {
     windows: HashMap<WindowId, WindowState>,
     last_window_idx: u32,
     main_window: Option<WindowId>,
+    /// An activation we asked for, until the deadline by which we stop
+    /// attributing activation and main window events to it.
     last_activated: Option<(Instant, Quiet, Option<WindowId>, oneshot::Sender<()>)>,
     is_frontmost: bool,
     raises_tx: Sender<(Span, RaiseRequest)>,
@@ -377,20 +383,30 @@ impl State {
     async fn handle_raises(this: &RefCell<Self>, mut rx: Receiver<(Span, RaiseRequest)>) {
         while let Some((span, raise)) = rx.recv().await {
             let RaiseRequest(wids, token, sequence_id, quiet) = raise;
-            if let Err(e) =
-                Self::handle_raise_request(this, wids.clone(), &token, sequence_id, quiet)
-                    .instrument(span)
-                    .await
+            match Self::handle_raise_request(this, wids.clone(), &token, sequence_id, quiet)
+                .instrument(span)
+                .await
             {
-                debug!("Raise request failed: {e}");
-                // Windows we didn't get to will never report completion, and
-                // the events the raise would have produced are suppressed, so
-                // tell the reactor the request is over.
-                this.borrow().send_event(Event::RaiseRequestFailed {
-                    windows: wids,
-                    sequence_id,
-                    quiet,
-                });
+                Ok(()) => {}
+                Err(RaiseError::RaiseCancelled) => {
+                    // Only the raise manager cancels, and it drops the pending
+                    // raises when it does. Reporting the failure would tell the
+                    // reactor the focus is where it was before the raise, which
+                    // is wrong if the activation we already asked for lands.
+                    debug!("Raise request cancelled");
+                    this.borrow_mut().expire_pending_activation();
+                }
+                Err(e) => {
+                    debug!("Raise request failed: {e}");
+                    // Windows we didn't get to will never report completion,
+                    // and the events the raise would have produced are
+                    // suppressed, so tell the reactor the request is over.
+                    this.borrow().send_event(Event::RaiseRequestFailed {
+                        windows: wids,
+                        sequence_id,
+                        quiet,
+                    });
+                }
             }
         }
     }
@@ -928,11 +944,24 @@ impl State {
     /// set with no activation event coming to consume it, and the user may
     /// focus the same window before it ages out.
     fn take_pending_quiet_window_change(&mut self) -> Option<WindowId> {
-        let (ts, _, quiet_window_change, _) = self.last_activated.as_mut()?;
-        if ts.elapsed() >= ACTIVATION_TIMEOUT {
+        let (deadline, _, quiet_window_change, _) = self.last_activated.as_mut()?;
+        if Instant::now() >= *deadline {
             return None;
         }
         quiet_window_change.take()
+    }
+
+    /// Shortens the window in which an activation is attributed to a raise that
+    /// was cancelled.
+    ///
+    /// The activation we asked for is already on its way, so it arrives well
+    /// within the grace period. If it never arrives, the app can still be
+    /// activated by the user, and that activation is not ours to quiet.
+    fn expire_pending_activation(&mut self) {
+        let Some((deadline, ..)) = self.last_activated.as_mut() else {
+            return;
+        };
+        *deadline = (*deadline).min(Instant::now() + CANCELLED_ACTIVATION_GRACE);
     }
 
     fn on_main_window_changed(&mut self, quiet_if: Option<WindowId>) -> Option<WindowId> {
@@ -1013,12 +1042,12 @@ impl State {
                 // reason, we are stuck with using a timeout so we don't
                 // suppress real events in the future.
                 //
-                // This is independent of the raise request cancellation,
-                // which can be caused by outside factors. If last_activated was
-                // set, it's because we initiated an activation event, so we
-                // still want to mark it as quiet if applicable.
-                Some((ts, quiet_activation, quiet_window_change, tx))
-                    if ts.elapsed() < ACTIVATION_TIMEOUT =>
+                // A cancelled raise only shortens the deadline. If
+                // last_activated was set, it's because we initiated an
+                // activation event, so we still want to mark it as quiet if
+                // applicable.
+                Some((deadline, quiet_activation, quiet_window_change, tx))
+                    if Instant::now() < deadline =>
                 {
                     // Initiated by us.
                     trace!("by us");
@@ -1053,7 +1082,12 @@ impl State {
         token: &CancellationToken,
     ) -> Result<(), RaiseError> {
         let (tx, rx) = oneshot::channel();
-        this.last_activated = Some((Instant::now(), quiet_activation, quiet_window_change, tx));
+        this.last_activated = Some((
+            Instant::now() + ACTIVATION_TIMEOUT,
+            quiet_activation,
+            quiet_window_change,
+            tx,
+        ));
         drop(this); // Don't use RefCell across await.
         trace!("Awaiting activation");
         select! {

--- a/src/actor/app.rs
+++ b/src/actor/app.rs
@@ -377,11 +377,20 @@ impl State {
     async fn handle_raises(this: &RefCell<Self>, mut rx: Receiver<(Span, RaiseRequest)>) {
         while let Some((span, raise)) = rx.recv().await {
             let RaiseRequest(wids, token, sequence_id, quiet) = raise;
-            if let Err(e) = Self::handle_raise_request(this, wids, &token, sequence_id, quiet)
-                .instrument(span)
-                .await
+            if let Err(e) =
+                Self::handle_raise_request(this, wids.clone(), &token, sequence_id, quiet)
+                    .instrument(span)
+                    .await
             {
                 debug!("Raise request failed: {e}");
+                // Windows we didn't get to will never report completion, and
+                // the events the raise would have produced are suppressed, so
+                // tell the reactor the request is over.
+                this.borrow().send_event(Event::RaiseRequestFailed {
+                    windows: wids,
+                    sequence_id,
+                    quiet,
+                });
             }
         }
     }

--- a/src/actor/app.rs
+++ b/src/actor/app.rs
@@ -675,7 +675,7 @@ impl State {
                 // A raise we started may be waiting on the activation event
                 // that goes with this change. The app can report the new main
                 // window first, so use the marker the raise left behind.
-                let quiet_if = self.pending_quiet_window_change();
+                let quiet_if = self.take_pending_quiet_window_change();
                 self.on_main_window_changed(quiet_if);
             }
             kAXWindowCreatedNotification => {
@@ -913,12 +913,17 @@ impl State {
         Ok(())
     }
 
-    /// The window an in-flight raise expects to become the main window.
-    fn pending_quiet_window_change(&self) -> Option<WindowId> {
-        self.last_activated
-            .as_ref()
-            .filter(|(ts, ..)| ts.elapsed() < ACTIVATION_TIMEOUT)
-            .and_then(|&(_, _, quiet_window_change, _)| quiet_window_change)
+    /// Takes the window an in-flight raise expects to become the main window.
+    ///
+    /// Only applies to one main window change. A cancelled raise can leave this
+    /// set with no activation event coming to consume it, and the user may
+    /// focus the same window before it ages out.
+    fn take_pending_quiet_window_change(&mut self) -> Option<WindowId> {
+        let (ts, _, quiet_window_change, _) = self.last_activated.as_mut()?;
+        if ts.elapsed() >= ACTIVATION_TIMEOUT {
+            return None;
+        }
+        quiet_window_change.take()
     }
 
     fn on_main_window_changed(&mut self, quiet_if: Option<WindowId>) -> Option<WindowId> {

--- a/src/actor/app.rs
+++ b/src/actor/app.rs
@@ -167,6 +167,11 @@ pub enum Request {
 
 struct RaiseRequest(Vec<WindowId>, CancellationToken, u64, Quiet);
 
+/// How long after starting an activation we still attribute activation and main
+/// window events to it. Activations can silently fail to happen, so we can't
+/// wait indefinitely.
+const ACTIVATION_TIMEOUT: Duration = Duration::from_millis(1000);
+
 #[derive(Debug, Copy, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub enum Quiet {
     Yes,
@@ -667,7 +672,11 @@ impl State {
                 _ = self.on_activation_changed();
             }
             kAXMainWindowChangedNotification => {
-                self.on_main_window_changed(None);
+                // A raise we started may be waiting on the activation event
+                // that goes with this change. The app can report the new main
+                // window first, so use the marker the raise left behind.
+                let quiet_if = self.pending_quiet_window_change();
+                self.on_main_window_changed(quiet_if);
             }
             kAXWindowCreatedNotification => {
                 if self.id(&elem).is_ok() {
@@ -904,6 +913,14 @@ impl State {
         Ok(())
     }
 
+    /// The window an in-flight raise expects to become the main window.
+    fn pending_quiet_window_change(&self) -> Option<WindowId> {
+        self.last_activated
+            .as_ref()
+            .filter(|(ts, ..)| ts.elapsed() < ACTIVATION_TIMEOUT)
+            .and_then(|&(_, _, quiet_window_change, _)| quiet_window_change)
+    }
+
     fn on_main_window_changed(&mut self, quiet_if: Option<WindowId>) -> Option<WindowId> {
         // Always read back the main window instead of getting it from an event,
         // in case the event is stale. This is necessary because we sometimes
@@ -987,7 +1004,7 @@ impl State {
                 // set, it's because we initiated an activation event, so we
                 // still want to mark it as quiet if applicable.
                 Some((ts, quiet_activation, quiet_window_change, tx))
-                    if ts.elapsed() < Duration::from_millis(1000) =>
+                    if ts.elapsed() < ACTIVATION_TIMEOUT =>
                 {
                     // Initiated by us.
                     trace!("by us");

--- a/src/actor/app.rs
+++ b/src/actor/app.rs
@@ -874,8 +874,9 @@ impl State {
                 mutex_guard.take();
                 (quiet == Quiet::Yes).then_some(wid)
             } else {
-                // `quiet` only applies to the last window.
-                None
+                // `quiet` only applies to the last window. The ones below it
+                // should always be quiet.
+                Some(wid)
             };
 
             // Observe the main window change and send the event if applicable.

--- a/src/actor/raise.rs
+++ b/src/actor/raise.rs
@@ -28,6 +28,10 @@ pub enum Event {
         window_id: WindowId,
         sequence_id: u64,
     },
+    RaiseRequestFailed {
+        windows: Vec<WindowId>,
+        sequence_id: u64,
+    },
     RaiseTimeout {
         sequence_id: u64,
     },
@@ -164,6 +168,19 @@ impl RaiseManager {
                 if let Some(sequence) = &mut self.active_sequence {
                     if sequence.sequence_id == sequence_id {
                         sequence.pending_raises.remove(&window_id);
+                    }
+                }
+            }
+            Event::RaiseRequestFailed { windows, sequence_id } => {
+                debug!("Raise request failed for {windows:?} in sequence {sequence_id}");
+
+                // The app won't report completion for these, so stop waiting on
+                // them instead of holding the sequence until it times out.
+                if let Some(sequence) = &mut self.active_sequence {
+                    if sequence.sequence_id == sequence_id {
+                        for window_id in windows {
+                            sequence.pending_raises.remove(&window_id);
+                        }
                     }
                 }
             }
@@ -764,6 +781,66 @@ mod tests {
             // Verify all sequences completed
             assert!(raise_manager.active_sequence.is_none());
             assert!(collect_requests(&mut app_rx).is_empty());
+        });
+    }
+
+    #[test]
+    fn test_failed_raise_does_not_block_the_sequence() {
+        Executor::run(async {
+            let mut raise_manager = RaiseManager::new();
+            let (app_handles, mut app_rx) = create_test_app_handles();
+
+            let msg = create_layout_response(
+                vec![WindowId::new(1, 1)],
+                Some((WindowId::new(1, 2), None)),
+                app_handles.clone(),
+            );
+            raise_manager.handle_message(msg);
+
+            let requests = collect_requests(&mut app_rx);
+            assert_eq!(requests.len(), 1);
+            assert_raise_request(&requests[0], WindowId::new(1, 1), 1, Quiet::Yes);
+
+            // The regular raise fails, so the focus raise goes out anyway.
+            raise_manager.handle_message(Event::RaiseRequestFailed {
+                windows: vec![WindowId::new(1, 1)],
+                sequence_id: 1,
+            });
+            let requests = collect_requests(&mut app_rx);
+            assert_eq!(requests.len(), 1);
+            assert_raise_request(&requests[0], WindowId::new(1, 2), 1, Quiet::No);
+
+            // The focus raise fails too, ending the sequence.
+            raise_manager.handle_message(Event::RaiseRequestFailed {
+                windows: vec![WindowId::new(1, 2)],
+                sequence_id: 1,
+            });
+            assert!(raise_manager.active_sequence.is_none());
+        });
+    }
+
+    #[test]
+    fn test_failed_raise_from_an_old_sequence_is_ignored() {
+        Executor::run(async {
+            let mut raise_manager = RaiseManager::new();
+            let (app_handles, mut app_rx) = create_test_app_handles();
+
+            let msg = create_layout_response(
+                vec![WindowId::new(1, 1)],
+                Some((WindowId::new(1, 2), None)),
+                app_handles.clone(),
+            );
+            raise_manager.handle_message(msg);
+            _ = collect_requests(&mut app_rx);
+
+            raise_manager.handle_message(Event::RaiseRequestFailed {
+                windows: vec![WindowId::new(1, 1)],
+                sequence_id: 0,
+            });
+
+            let sequence = raise_manager.active_sequence.as_ref().unwrap();
+            assert_eq!(sequence.sequence_id, 1);
+            assert!(sequence.pending_raises.contains(&WindowId::new(1, 1)));
         });
     }
 

--- a/src/actor/reactor.rs
+++ b/src/actor/reactor.rs
@@ -165,6 +165,17 @@ pub enum Event {
         sequence_id: u64,
     },
 
+    /// A raise request failed. None of its windows will be raised.
+    ///
+    /// `quiet` is the one the request was made with. A non-quiet request was
+    /// meant to move the focus, so the layout has to be reconciled with the
+    /// main window that is actually focused.
+    RaiseRequestFailed {
+        windows: Vec<WindowId>,
+        sequence_id: u64,
+        quiet: Quiet,
+    },
+
     /// A raise sequence timed out. Used by the raise manager to clean up
     /// pending raises that took too long.
     RaiseTimeout {
@@ -757,6 +768,18 @@ impl Reactor {
             Event::RaiseCompleted { window_id, sequence_id } => {
                 let msg = raise::Event::RaiseCompleted { window_id, sequence_id };
                 _ = self.raise_manager_tx.send((Span::current(), msg));
+            }
+            Event::RaiseRequestFailed { windows, sequence_id, quiet } => {
+                let msg = raise::Event::RaiseRequestFailed { windows, sequence_id };
+                _ = self.raise_manager_tx.send((Span::current(), msg));
+                if quiet == Quiet::No
+                    && let Some(main_window) = self.main_window()
+                {
+                    // The raise didn't move the focus, so bring the layout
+                    // selection back to the window that has it.
+                    let spaces = self.screens.iter().flat_map(|screen| screen.space).collect();
+                    self.send_layout_event(LayoutEvent::WindowFocused(spaces, main_window));
+                }
             }
             Event::RaiseTimeout { sequence_id } => {
                 let msg = raise::Event::RaiseTimeout { sequence_id };

--- a/src/actor/reactor/main_window.rs
+++ b/src/actor/reactor/main_window.rs
@@ -88,6 +88,7 @@ impl MainWindowTracker {
             | Event::MouseUp
             | Event::MouseMovedOverWindow(..)
             | Event::RaiseCompleted { .. }
+            | Event::RaiseRequestFailed { .. }
             | Event::RaiseTimeout { .. }
             | Event::ScrollWheel { .. }
             | Event::LeftMouseDown(_)
@@ -269,6 +270,56 @@ mod tests {
         ));
         assert_eq!(Some(WindowId::new(1, 2)), reactor.main_window());
         assert_eq!(reactor.layout.selected_window(space), Some(WindowId::new(1, 2)));
+    }
+
+    #[test]
+    fn it_restores_the_layout_selection_when_a_focus_raise_fails() {
+        use Event::*;
+        use objc2_core_foundation::{CGPoint, CGSize};
+
+        use super::super::Command;
+        use crate::actor::layout::LayoutCommand;
+        use crate::model::Direction;
+        let mut apps = Apps::new();
+        let mut reactor = Reactor::new_for_test(LayoutManager::new_for_test());
+        let space = SpaceId::new(1);
+        reactor.handle_event(ScreenParametersChanged {
+            frames: vec![CGRect::new(CGPoint::ZERO, CGSize::new(1000., 1000.))],
+            spaces: vec![Some(space)],
+
+            converter: CoordinateConverter::default(),
+            scale_factors: vec![2.0],
+            on_screen: Default::default(),
+        });
+
+        reactor.handle_event(ApplicationGloballyActivated(1));
+        reactor.handle_events(apps.make_app_with_opts(
+            1,
+            make_windows(2),
+            Some(WindowId::new(1, 1)),
+            true,
+        ));
+        assert_eq!(Some(WindowId::new(1, 1)), reactor.main_window());
+
+        reactor.handle_event(Event::Command(Command::Layout(LayoutCommand::MoveFocus(
+            Direction::Right,
+        ))));
+        assert_eq!(reactor.layout.selected_window(space), Some(WindowId::new(1, 2)));
+
+        // A quiet raise failing says nothing about where the focus is.
+        reactor.handle_event(RaiseRequestFailed {
+            windows: vec![WindowId::new(1, 2)],
+            sequence_id: 1,
+            quiet: Quiet::Yes,
+        });
+        assert_eq!(reactor.layout.selected_window(space), Some(WindowId::new(1, 2)));
+
+        reactor.handle_event(RaiseRequestFailed {
+            windows: vec![WindowId::new(1, 2)],
+            sequence_id: 1,
+            quiet: Quiet::No,
+        });
+        assert_eq!(reactor.layout.selected_window(space), Some(WindowId::new(1, 1)));
     }
 
     #[test]

--- a/src/actor/window_server.rs
+++ b/src/actor/window_server.rs
@@ -42,7 +42,15 @@ pub struct WindowServer {
     screen_config_retry_attempt: u8,
     screen_config_retry_pending: bool,
     /// The screen configuration last sent downstream.
-    last_screen_config: Option<(Vec<ScreenInfo>, Vec<Option<SpaceId>>)>,
+    last_screen_config: Option<ScreenConfig>,
+}
+
+/// A screen configuration, along with the window order it was sent with.
+#[derive(Clone, PartialEq)]
+struct ScreenConfig {
+    screens: Vec<ScreenInfo>,
+    spaces: Vec<Option<SpaceId>>,
+    visible: Vec<WindowServerId>,
 }
 
 #[derive(Debug)]
@@ -187,16 +195,23 @@ impl WindowServer {
 
         // The system has been observed to send long runs of this notification
         // with no actual change; drop them here so the rest of the system never
-        // sees them.
-        let config = (screens, self.screen_cache.get_screen_spaces());
+        // sees them. The windows on screen have to be unchanged too: an
+        // identical configuration is also reported after the system restacks
+        // windows, and that is our cue to put them back. Compare the order
+        // alone, so windows that are merely moving don't count as a change.
+        let on_screen = self.get_windows_on_screen();
+        let config = ScreenConfig {
+            screens,
+            spaces: self.screen_cache.get_screen_spaces(),
+            visible: on_screen.visible.clone(),
+        };
         if self.last_screen_config.as_ref() == Some(&config) {
             debug!("Screen configuration is unchanged");
             return;
         }
         self.last_screen_config = Some(config.clone());
-        let (screens, spaces) = config;
+        let ScreenConfig { screens, spaces, .. } = config;
 
-        let on_screen = self.get_windows_on_screen();
         self.sm_tx.send(space_manager::Event::ScreenParametersChanged {
             screens: screens.iter().map(|s| s.id).collect(),
             frames: screens.iter().map(|s| s.visible_frame).collect(),


### PR DESCRIPTION
Focus would land on a window the user never touched: the layout selection jumped to windows Glide itself had raised, and repeated screen notifications restacked windows that were already in place. These came out of log analysis of the focus flicker.